### PR TITLE
Add ability to launch sites with the WooCommerce Beta Tester plugin installed

### DIFF
--- a/features/woocommerce-beta-tester.php
+++ b/features/woocommerce-beta-tester.php
@@ -16,6 +16,38 @@ add_action( 'jurassic_ninja_init', function() {
 			add_woocommerce_beta_tester_plugin();
 		}
 	}, 10, 3 );
+
+	add_filter( 'jurassic_ninja_rest_feature_defaults', function( $defaults ) {
+		return array_merge( $defaults, [
+			'woocommerce-beta-tester' => (bool) settings( 'add_woocommerce_beta_tester_by_default', false ),
+		] );
+	} );
+
+	add_filter( 'jurassic_ninja_rest_create_request_features', function( $features, $json_params ) {
+		if ( isset( $json_params['woocommerce-beta-tester'] ) ) {
+			$features['woocommerce-beta-tester'] = $json_params['woocommerce-beta-tester'];
+			// The WooCommerce Beta Tester Plugin works only when woocommerce is installed and active too
+			if ( $features['woocommerce-beta-tester'] ) {
+				$features['woocommerce'] = true;
+			}
+		}
+		return $features;
+	}, 10, 2 );
+} );
+
+add_action( 'jurassic_ninja_admin_init', function( $fields ) {
+	add_filter( 'jurassic_ninja_settings_options_page_default_plugins', function( $fields ) {
+		$field = [
+			'add_woocommerce_beta_tester_by_default' => [
+				'id' => 'add_woocommerce_beta_tester_by_default',
+				'title' => __( 'Add WooCommerce Beta Tester plugin to every launched WordPress', 'jurassic-ninja' ),
+				'text' => __( 'Install and activate WooCommerce Beta Tester on launch', 'jurassic-ninja' ),
+				'type' => 'checkbox',
+				'checked' => false,
+			],
+		];
+		return array_merge( $fields, $field );
+	}, 10 );
 } );
 
 /**

--- a/features/woocommerce-beta-tester.php
+++ b/features/woocommerce-beta-tester.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace jn;
+
+define( 'WOOCOMMERCE_BETA_TESTER_PLUGIN_URL', 'https://github.com/woocommerce/woocommerce-beta-tester/archive/master.zip' );
+
+add_action( 'jurassic_ninja_init', function() {
+	$defaults = [
+		'woocommerce-beta-tester' => false,
+	];
+
+	add_action( 'jurassic_ninja_add_features_before_auto_login', function( &$app, $features, $domain ) use ( $defaults ) {
+		$features = array_merge( $defaults, $features );
+		if ( $features['woocommerce-beta-tester'] ) {
+			debug( '%s: Adding WooCommerce Beta Tester Plugin', $domain );
+			add_woocommerce_beta_tester_plugin();
+		}
+	}, 10, 3 );
+} );
+
+/**
+ * Installs and activates WooCommerce Beta Tester plugin on the site.
+ */
+function add_woocommerce_beta_tester_plugin() {
+	$woocommerce_beta_tester_plugin_url = WOOCOMMERCE_BETA_TESTER_PLUGIN_URL;
+	$cmd = "wp plugin install $woocommerce_beta_tester_plugin_url --activate";
+	add_filter( 'jurassic_ninja_feature_command', function ( $s ) use ( $cmd ) {
+		return "$s && $cmd";
+	} );
+}

--- a/features/woocommerce-beta-tester.php
+++ b/features/woocommerce-beta-tester.php
@@ -33,6 +33,17 @@ add_action( 'jurassic_ninja_init', function() {
 		}
 		return $features;
 	}, 10, 2 );
+
+	add_filter( 'jurassic_ninja_rest_specialops_create_request_features', function( $features, $json_params ) {
+		if ( isset( $json_params['woocommerce-beta-tester'] ) ) {
+			$features['woocommerce-beta-tester'] = $json_params['woocommerce-beta-tester'];
+			// The WooCommerce Beta Tester Plugin works only when woocommerce is installed and active too
+			if ( $features['woocommerce-beta-tester'] ) {
+				$features['woocommerce'] = true;
+			}
+		}
+		return $features;
+	}, 10, 2 );
 } );
 
 add_action( 'jurassic_ninja_admin_init', function( $fields ) {

--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -3,7 +3,7 @@
 /*
  * Plugin Name: Jurassic Ninja
  * Description: Launch ephemeral instances of WordPress + Jetpack using ServerPilot and an Ubuntu Box.
- * Version: 3.4
+ * Version: 3.5
  * Author: Osk
  **/
 

--- a/lib/rest-api-stuff.php
+++ b/lib/rest-api-stuff.php
@@ -89,8 +89,8 @@ function add_rest_api_endpoints() {
 		 * Filters the features requested through the /specialops/create REST API endpoint
 		 *
 		 * Should only hook here for special cases.
-		 * Like in the case of the WooCommerce Beta Tester which currently is functionless
-		 * unless WooCommerce is installed too.
+		 * Like in the case of the WooCommerce Beta Tester which currently provides no functionality unless
+		 * WooCommerce is installed too.
 		 *
 		 * If any filter returns a WP_Error, then the request is finished with status 500
 		 *

--- a/lib/rest-api-stuff.php
+++ b/lib/rest-api-stuff.php
@@ -45,11 +45,10 @@ function add_rest_api_endpoints() {
 		 */
 		$features = apply_filters( 'jurassic_ninja_rest_create_request_features', $features, $json_params );
 		// Check if any feature errored
-		foreach( $features as $feature ) {
+		foreach ( $features as $feature ) {
 			if ( is_wp_error( $feature ) ) {
 				return $feature;
 			}
-
 		}
 
 		$data = launch_wordpress( 'default', $features );
@@ -86,6 +85,25 @@ function add_rest_api_endpoints() {
 
 		$features = $json_params && is_array( $json_params ) ? $json_params : [];
 		$features = array_merge( $defaults, $features );
+		/**
+		 * Filters the features requested through the /specialops/create REST API endpoint
+		 *
+		 * Should only hook here for special cases.
+		 * Like in the case of the WooCommerce Beta Tester which currently is functionless
+		 * unless WooCommerce is installed too.
+		 *
+		 * If any filter returns a WP_Error, then the request is finished with status 500
+		 *
+		 * @param array $features    The current feature flags.
+		 * @param array $json_params The body of the json request.
+		 */
+		$features = apply_filters( 'jurassic_ninja_rest_specialops_create_request_features', $features, $json_params );
+		// Check if any feature errored
+		foreach ( $features as $feature ) {
+			if ( is_wp_error( $feature ) ) {
+				return $feature;
+			}
+		}
 		if ( ! settings( 'enable_launching', true ) ) {
 			return new \WP_Error( 'site_launching_disabled', __( 'Site launching is disabled right now' ), [
 				'status' => 503,

--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -66,6 +66,7 @@ function require_feature_files() {
 		'/features/gutenberg.php',
 		'/features/jetpack-beta.php',
 		'/features/woocommerce.php',
+		'/features/woocommerce-beta-tester.php',
 		'/features/wordpress-beta-tester.php',
 		'/features/wp-debug-log.php',
 		'/features/wp-log-viewer.php',


### PR DESCRIPTION
Requesting for a site with the WooCommerce Beta Tester feature will implicitly install WooCommerce. 

The WooCommerce Beta Tester plugin currently provides the ability to check the latest tagged version in the GitHub Repository for WooCommerce

https://github.com/woocommerce/woocommerce/tags