### PR TITLE
Use the logged in user email address for the launched site

### DIFF
--- a/features/logged-in-user-email-address.php
+++ b/features/logged-in-user-email-address.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Implements the feature to launch sites with the user's email address.
+ *
+ * If the user launching a site is logged in, the site Admin email address and the admin user's Address
+ * we will the one of the user launching the site.
+ *
+ */
+
+namespace jn;
+
+if ( ! defined( '\\ABSPATH' ) ) {
+	exit;
+}
+
+add_action( 'jurassic_ninja_init', function() {
+	add_filter( 'jurassic_ninja_wordpress_options', function( $wordpress_options ) {
+		// Use the logged in user's email address as the site's email address
+		if ( is_user_logged_in() && settings( 'use_user_email_as_admin_email', false ) ) {
+			$user = wp_get_current_user();
+			$wordpress_options['admin_email'] = $user->user_email;
+		}
+		return $wordpress_options;
+	} );
+} );
+

--- a/features/logged-in-user-email-address.php
+++ b/features/logged-in-user-email-address.php
@@ -24,3 +24,17 @@ add_action( 'jurassic_ninja_init', function() {
 	} );
 } );
 
+add_action( 'jurassic_ninja_admin_init', function() {
+	add_filter( 'jurassic_ninja_settings_options_page', function( $options_page ) {
+		$field = [
+			'id' => 'use_user_email_as_admin_email',
+			'title' => __( 'Set the user\'s email address as the site\'s admin email address', 'jurassic-ninja' ),
+			'text' => __( 'If the user launching a site is logged in, use their email address for the site', 'jurassic-ninja' ),
+			'type' => 'checkbox',
+			'checked' => false,
+		];
+		$options_page[ SETTINGS_KEY ]['sections']['domain']['fields']['use_user_email_as_admin_email'] = $field;
+		return $options_page;
+	}, 10 );
+} );
+

--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -3,7 +3,7 @@
 /*
  * Plugin Name: Jurassic Ninja
  * Description: Launch ephemeral instances of WordPress + Jetpack using ServerPilot and an Ubuntu Box.
- * Version: 3.5
+ * Version: 3.6
  * Author: Osk
  **/
 

--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -75,7 +75,7 @@ function require_feature_files() {
 		'/features/wp-rollback.php',
 	];
 
-	$available_features =  apply_filters( 'jurassic_ninja_available_features', $available_features );
+	$available_features = apply_filters( 'jurassic_ninja_available_features', $available_features );
 	foreach( $available_features as $feature_file ) {
 		require_once PLUGIN_DIR . $feature_file;
 	}

--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -58,6 +58,7 @@ function add_auto_login( $password, $sysuser ) {
  */
 function require_feature_files() {
 	$available_features = [
+		'/features/logged-in-user-email-address.php',
 		'/features/multisite.php',
 		'/features/ssl.php',
 		'/features/plugins.php',


### PR DESCRIPTION
#### Changes introduced by this PR

* Allows to Make the admin email address of the site be the user's if the user is logged in while launching a site
* Adds setting for this.
* Bumps version to 3.6