### PR TITLE
Add ability to launch sites with latest beta release of WordPress 5.0

### DIFF
--- a/features/wordpress-5-beta.php
+++ b/features/wordpress-5-beta.php
@@ -2,7 +2,6 @@
 
 namespace jn;
 
-
 add_action( 'jurassic_ninja_init', function() {
 	$defaults = [
 		'wordpress-5-beta' => false,

--- a/features/wordpress-5-beta.php
+++ b/features/wordpress-5-beta.php
@@ -24,9 +24,14 @@ add_action( 'jurassic_ninja_init', function() {
 	add_filter( 'jurassic_ninja_rest_create_request_features', function( $features, $json_params ) {
 		if ( isset( $json_params['wordpress-5-beta'] ) ) {
 			$features['wordpress-5-beta'] = $json_params['wordpress-5-beta'];
+			// Disable launching with Gutenberg if WordPress 5.0 is requested
+			// Just in case they collide at some point
+			if ( isset( $json_params['gutenberg'] ) ) {
+				$features['gutenberg'] = false;
+			}
 		}
 		return $features;
-	}, 10, 2 );
+	}, 11, 2 );
 
 } );
 

--- a/features/wordpress-5-beta.php
+++ b/features/wordpress-5-beta.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace jn;
+
+
+add_action( 'jurassic_ninja_init', function() {
+	$defaults = [
+		'wordpress-5-beta' => false,
+	];
+
+	add_action( 'jurassic_ninja_add_features_before_auto_login', function( &$app = null, $features, $domain ) use ( $defaults ) {
+		$features = array_merge( $defaults, $features );
+		if ( $features['wordpress-5-beta'] ) {
+			debug( '%s: Updating core to latest WordPress 5 beta release', $domain );
+			update_to_wordpress_5_beta_latest();
+		}
+	}, 10, 3 );
+
+	add_filter( 'jurassic_ninja_rest_feature_defaults', function( $defaults ) {
+		return array_merge( $defaults, [
+			'wordpress-5-beta' => false,
+		] );
+	} );
+
+	add_filter( 'jurassic_ninja_rest_create_request_features', function( $features, $json_params ) {
+		if ( isset( $json_params['wordpress-5-beta'] ) ) {
+			$features['wordpress-5-beta'] = $json_params['wordpress-5-beta'];
+		}
+		return $features;
+	}, 10, 2 );
+
+} );
+
+add_action( 'jurassic_ninja_admin_init', function() {
+	add_filter( 'jurassic_ninja_settings_options_page_default_plugins', function( $fields ) {
+		$field = [
+			'wordpress_5_beta_latest' => [
+				'id' => 'wordpress_5_beta_latest',
+				'title' => __( 'Latest beta tag for WordPress 5.0', 'jurassic-ninja' ),
+				'text' => __( 'Which version to run when wordpress-5-beta requested', 'jurassic-ninja' ),
+				'placeholder' => '5.0-beta1',
+				'value' => '5.0-beta1',
+				'checked' => false,
+			],
+		];
+		return array_merge( $fields, $field );
+	}, 10 );
+} );
+
+/**
+ * Updates WordPress to latest Beta available for 5.0.
+ */
+function update_to_wordpress_5_beta_latest() {
+	$wordpress_5_beta_latest = settings( 'wordpress_5_beta_latest', '5.0-beta1' );
+	$cmd = "wp core update --version=$wordpress_5_beta_latest && wp core update-db";
+	add_filter( 'jurassic_ninja_feature_command', function ( $s ) use ( $cmd ) {
+		return "$s && $cmd";
+	} );
+}

--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -3,7 +3,7 @@
 /*
  * Plugin Name: Jurassic Ninja
  * Description: Launch ephemeral instances of WordPress + Jetpack using ServerPilot and an Ubuntu Box.
- * Version: 4.2-beta4
+ * Version: 4.2
  * Author: Automattic
  **/
 

--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -68,6 +68,7 @@ function require_feature_files() {
 		'/features/woocommerce-beta-tester.php',
 		'/features/wp-debug-log.php',
 		'/features/gutenpack.php',
+		'/features/wordpress-5-beta.php',
 	];
 
 	$available_features = apply_filters( 'jurassic_ninja_available_features', $available_features );


### PR DESCRIPTION
* Introduces the feature `wordpress-5-beta` available from the Special Ops page and as a `GET` parameter to the Create Page.
* Bumps version to `4.2`