### PR TITLE
Add ability to launch sites with the WooCommerce Smooth Generator plugin

### DIFF
--- a/features/plugins.php
+++ b/features/plugins.php
@@ -2,6 +2,13 @@
 
 namespace jn;
 
+/**
+ *
+ * This feature allows installation of a few whitelisted plugins that are available on
+ * the Plugin Directory.
+ *
+ */
+
 add_action( 'jurassic_ninja_init', function() {
 	$whitelist = [
 		'code-snippets' => 'Code Snippets',

--- a/features/wc-smooth-generator.php
+++ b/features/wc-smooth-generator.php
@@ -47,7 +47,7 @@ function add_wc_smooth_generator_plugin() {
 	 */
 	$cmd = "wp plugin install $wc_smooth_generator_plugin_url"
 		. ' && pushd . && cd wp-content/plugins/wc-smooth-generator'
-		. ' && composer install'
+		. ' && composer install --no-dev'
 		. ' && wp plugin activate wc-smooth-generator'
 		. ' && popd';
 

--- a/features/wc-smooth-generator.php
+++ b/features/wc-smooth-generator.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace jn;
+
+define( 'WC_SMOOTH_GENERATOR_PLUGIN_URL', 'https://github.com/woocommerce/wc-smooth-generator/archive/master.zip' );
+
+add_action( 'jurassic_ninja_init', function() {
+	$defaults = [
+		'wc-smooth-generator' => false,
+	];
+
+	add_action( 'jurassic_ninja_add_features_before_auto_login', function( &$app = null, $features, $domain ) use ( $defaults ) {
+		$features = array_merge( $defaults, $features );
+		if ( $features['wc-smooth-generator'] ) {
+			debug( '%s: Adding WooCommerce Smooth Generator Plugin', $domain );
+			add_wc_smooth_generator_plugin();
+		}
+	}, 10, 3 );
+
+	add_filter( 'jurassic_ninja_rest_feature_defaults', function( $defaults ) {
+		return array_merge( $defaults, [
+			'wc-smooth-generator' => false,
+		] );
+	} );
+
+	add_filter( 'jurassic_ninja_rest_create_request_features', function( $features, $json_params ) {
+		if ( isset( $json_params['wc-smooth-generator'] ) ) {
+			$features['wc-smooth-generator'] = $json_params['wc-smooth-generator'];
+			// The WooCommerce Smooth Generator Plugin is meant to work alongside
+			// WooCommerce and active.
+			if ( $features['wc-smooth-generator'] ) {
+				$features['woocommerce'] = true;
+			}
+		}
+		return $features;
+	}, 10, 2 );
+
+} );
+
+/**
+ * Installs and activates WooCommerce Beta Tester plugin on the site.
+ */
+function add_wc_smooth_generator_plugin() {
+	$wc_smooth_generator_plugin_url = WC_SMOOTH_GENERATOR_PLUGIN_URL;
+	$cmd = "wp plugin install $wc_smooth_generator_plugin_url --activate"
+		. ' && pushd . && cd wp-content/plugins/wc-smooth-generator'
+		. ' && composer install'
+		. ' && popd';
+
+	add_filter( 'jurassic_ninja_feature_command', function ( $s ) use ( $cmd ) {
+		return "$s && $cmd";
+	} );
+}

--- a/features/wc-smooth-generator.php
+++ b/features/wc-smooth-generator.php
@@ -42,9 +42,13 @@ add_action( 'jurassic_ninja_init', function() {
  */
 function add_wc_smooth_generator_plugin() {
 	$wc_smooth_generator_plugin_url = WC_SMOOTH_GENERATOR_PLUGIN_URL;
-	$cmd = "wp plugin install $wc_smooth_generator_plugin_url --activate"
+	/**
+	 * We install the plugin but don't activate until dependencies are there or it will fail
+	 */
+	$cmd = "wp plugin install $wc_smooth_generator_plugin_url"
 		. ' && pushd . && cd wp-content/plugins/wc-smooth-generator'
 		. ' && composer install'
+		. ' && wp plugin activate wc-smooth-generator'
 		. ' && popd';
 
 	add_filter( 'jurassic_ninja_feature_command', function ( $s ) use ( $cmd ) {

--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -3,7 +3,7 @@
 /*
  * Plugin Name: Jurassic Ninja
  * Description: Launch ephemeral instances of WordPress + Jetpack using ServerPilot and an Ubuntu Box.
- * Version: 4.2
+ * Version: 4.3
  * Author: Automattic
  **/
 

--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -65,6 +65,7 @@ function require_feature_files() {
 		'/features/ssl.php',
 		'/features/plugins.php',
 		'/features/jetpack-beta.php',
+		'/features/wc-smooth-generator.php',
 		'/features/woocommerce-beta-tester.php',
 		'/features/wp-debug-log.php',
 		'/features/gutenpack.php',


### PR DESCRIPTION
The plugin [WC Smooth Generator](https://github.com/woocommerce/wc-smooth-generator/) generates products, orders, and customer users on a site for making it quick to test on an empty site or on one where WooCommerce has recently been installed for the first time. 

This will alow one to launch a site and be able to SSh into it for using WP CLI like it's described in [WC Smooth Generator's README](https://github.com/woocommerce/wc-smooth-generator/blob/master/README.md):



```
wp wc generate products <nr of products>
```

#### Why

This comes in handy for WooCommerce testing but also for when some smoke tests need to be done on a Jetpack site interacting with WooCommerce.  (Lazy Images, Jetpack connection, Gutenberg blocks, etc)