### PR TITLE
Add ability to launch with bleeding edge Gutenberg (master branch)

### DIFF
--- a/features/gutenberg-master.php
+++ b/features/gutenberg-master.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace jn;
+
+add_action( 'jurassic_ninja_init', function() {
+	$defaults = [
+		'gutenberg-master' => false,
+	];
+
+	add_action( 'jurassic_ninja_add_features_before_auto_login', function( &$app = null, $features, $domain ) use ( $defaults ) {
+		$features = array_merge( $defaults, $features );
+		if ( $features['gutenberg-master'] ) {
+			debug( '%s: Adding bleeding edge Gutenberg plugin', $domain );
+			add_gutenberg_master();
+		}
+	}, 10, 3 );
+
+	add_filter( 'jurassic_ninja_rest_feature_defaults', function( $defaults ) {
+		return array_merge( $defaults, [
+			'gutenberg-master' => false,
+		] );
+	} );
+
+	add_filter( 'jurassic_ninja_rest_create_request_features', function( $features, $json_params ) {
+		if ( isset( $json_params['gutenberg-master'] ) ) {
+			$features['gutenberg-master'] = $json_params['gutenberg-master'];
+		}
+		return $features;
+	}, 10, 2 );
+
+} );
+
+/**
+ * Installs and activates the bleeding edge version of the Gutenberg plugin from GitHub.
+ */
+function add_gutenberg_master() {
+	$cmd = 'curl https://gist.githubusercontent.com/oskosk/0b7c45522c945a62309dd57103f94133/raw/build-gutenberg-master.sh --output build-gutenberg-master.sh'
+		. ' && source build-gutenberg-master.sh'
+		. ' && wp plugin activate gutenberg';
+	add_filter( 'jurassic_ninja_feature_command', function ( $s ) use ( $cmd ) {
+		return "$s && $cmd";
+	} );
+}

--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -3,7 +3,7 @@
 /*
  * Plugin Name: Jurassic Ninja
  * Description: Launch ephemeral instances of WordPress + Jetpack using ServerPilot and an Ubuntu Box.
- * Version: 4.3
+ * Version: 4.4
  * Author: Automattic
  **/
 

--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -70,6 +70,7 @@ function require_feature_files() {
 		'/features/wp-debug-log.php',
 		'/features/gutenpack.php',
 		'/features/wordpress-5-beta.php',
+		'/features/gutenberg-master.php',
 	];
 
 	$available_features = apply_filters( 'jurassic_ninja_available_features', $available_features );


### PR DESCRIPTION

#### Changes introduced by this PR

* Adds the ability to launch with Gutenberg built from master via the paramter `?gutenberg-master`.
* Bumps plugin version to 4.4