### PR TITLE
Add ability to launch with a nightly release of Gutenberg

### DIFF
--- a/features/gutenberg-nightly.php
+++ b/features/gutenberg-nightly.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace jn;
+
+define( 'GUTENBERG_NIGHTLY_PLUGIN_URL', 'https://builds.danielbachhuber.com/gutenberg-nightly.zip' );
+
+add_action( 'jurassic_ninja_init', function() {
+	$defaults = [
+		'gutenberg-nightly' => false,
+	];
+
+	add_action( 'jurassic_ninja_add_features_before_auto_login', function( &$app = null, $features, $domain ) use ( $defaults ) {
+		$features = array_merge( $defaults, $features );
+		if ( $features['gutenberg-nightly'] ) {
+			debug( '%s: Adding Gutenberg nightly release Plugin', $domain );
+			add_gutenberg_nightly_plugin();
+		}
+	}, 10, 3 );
+
+	add_filter( 'jurassic_ninja_rest_feature_defaults', function( $defaults ) {
+		return array_merge( $defaults, [
+			'gutenberg-nightly' => false,
+		] );
+	} );
+
+	add_filter( 'jurassic_ninja_rest_create_request_features', function( $features, $json_params ) {
+		if ( isset( $json_params['gutenberg-nightly'] ) ) {
+			$features['gutenberg-nightly'] = $json_params['gutenberg-nightly'];
+		}
+		return $features;
+	}, 10, 2 );
+
+} );
+
+/**
+ * Installs and activates the Gutenberg Nightly plugin on the site.
+ * https://builds.danielbachhuber.com/gutenberg-nightly.zip
+ * https://danielbachhuber.com/2018/10/02/gutenberg-nightly-build/
+ */
+function add_gutenberg_nightly_plugin() {
+	$gutenberg_nightly_plugin_url = GUTENBERG_NIGHTLY_PLUGIN_URL;
+	$cmd = "wp plugin install $gutenberg_nightly_plugin_url --activate";
+	add_filter( 'jurassic_ninja_feature_command', function ( $s ) use ( $cmd ) {
+		return "$s && $cmd";
+	} );
+}

--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -3,7 +3,7 @@
 /*
  * Plugin Name: Jurassic Ninja
  * Description: Launch ephemeral instances of WordPress + Jetpack using ServerPilot and an Ubuntu Box.
- * Version: 4.4
+ * Version: 4.5
  * Author: Automattic
  **/
 

--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -69,8 +69,9 @@ function require_feature_files() {
 		'/features/woocommerce-beta-tester.php',
 		'/features/wp-debug-log.php',
 		'/features/gutenpack.php',
-		'/features/wordpress-5-beta.php',
 		'/features/gutenberg-master.php',
+		'/features/gutenberg-nightly.php',
+		'/features/wordpress-5-beta.php',
 	];
 
 	$available_features = apply_filters( 'jurassic_ninja_available_features', $available_features );


### PR DESCRIPTION
Thanks to Daniel Bachhuber who creates nightly bundles of Gutenberg's master branch every six hours, we can now launch sites with `?gutenberg-nightly` and have an alpha version of Gutenberg available on the site as it's launched.

https://danielbachhuber.com/2018/10/02/gutenberg-nightly-build/

#### Changes introduced by this PR

* Adds ability to launch a site with nightly Gutenberg via the `?gutenberg-nightly` parameter.
* Bumps plugin version to 4.5