### PR TITLE
Force WordPress 5 until ServerPilot starts installing it by default

### DIFF
--- a/features/wordpress-5-hack-until-serverpilot-updates.php
+++ b/features/wordpress-5-hack-until-serverpilot-updates.php
@@ -3,9 +3,6 @@
 namespace jn;
 
 add_action( 'jurassic_ninja_init', function() {
-	$defaults = [
-		'wordpress-5' => false,
-	];
 
 	add_action( 'jurassic_ninja_add_features_before_auto_login', function( &$app = null, $features, $domain ) {
 		if (
@@ -28,17 +25,9 @@ add_action( 'jurassic_ninja_admin_init', function() {
 				'id' => 'wordpress_5_hack',
 				'title' => __( 'Force launching of WordPress 5', 'jurassic-ninja' ),
 				'text' => __( 'Until ServerPilot starts installing WordPress 5, we need this hack.', 'jurassic-ninja' ),
-				'placeholder' => '5.0',
 				'type' => 'checkbox',
 				'checked' => false,
-			],
-			'wordpress_5_latest' => [
-				'id' => 'wordpress_5_latest',
-				'title' => __( 'Latest tag for WordPress 5.0', 'jurassic-ninja' ),
-				'text' => __( 'Which version to run when wordpress-5 requested', 'jurassic-ninja' ),
-				'placeholder' => '5.0',
-				'value' => '5.0',
-			],
+			]
 		];
 		return array_merge( $fields, $field );
 	}, 10 );
@@ -48,8 +37,7 @@ add_action( 'jurassic_ninja_admin_init', function() {
  * Updates WordPress to latest stable available for 5.0.
  */
 function update_to_wordpress_5_latest() {
-	$wordpress_5_latest = settings( 'wordpress_5_latest', '5.0' );
-	$cmd = "wp core update --version=$wordpress_5_latest && wp core update-db";
+	$cmd = "wp core update && wp core update-db";
 	add_filter( 'jurassic_ninja_feature_command', function ( $s ) use ( $cmd ) {
 		return "$s && $cmd";
 	} );

--- a/features/wordpress-5-hack-until-serverpilot-updates.php
+++ b/features/wordpress-5-hack-until-serverpilot-updates.php
@@ -27,7 +27,7 @@ add_action( 'jurassic_ninja_admin_init', function() {
 				'text' => __( 'Until ServerPilot starts installing WordPress 5, we need this hack.', 'jurassic-ninja' ),
 				'type' => 'checkbox',
 				'checked' => false,
-			]
+			],
 		];
 		return array_merge( $fields, $field );
 	}, 10 );
@@ -37,7 +37,7 @@ add_action( 'jurassic_ninja_admin_init', function() {
  * Updates WordPress to latest stable available for 5.0.
  */
 function update_to_wordpress_5_latest() {
-	$cmd = "wp core update && wp core update-db";
+	$cmd = 'wp core update && wp core update-db';
 	add_filter( 'jurassic_ninja_feature_command', function ( $s ) use ( $cmd ) {
 		return "$s && $cmd";
 	} );

--- a/features/wordpress-5-hack-until-serverpilot-updates.php
+++ b/features/wordpress-5-hack-until-serverpilot-updates.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace jn;
+
+add_action( 'jurassic_ninja_init', function() {
+	$defaults = [
+		'wordpress-5' => false,
+	];
+
+	add_action( 'jurassic_ninja_add_features_before_auto_login', function( &$app = null, $features, $domain ) {
+		if (
+			false === settings( 'wordpress_5_hack', false )
+			// Do not upgrade if wordpress-4 was requested
+			|| ( isset( $features['wordpress-4'] ) && $features['wordpress-4'] )
+		) {
+			return;
+		}
+		debug( '%s: Updating core to latest WordPress 5 release', $domain );
+		update_to_wordpress_5_latest();
+	}, 10, 3 );
+
+} );
+
+add_action( 'jurassic_ninja_admin_init', function() {
+	add_filter( 'jurassic_ninja_settings_options_page_default_plugins', function( $fields ) {
+		$field = [
+			'wordpress_5_hack' => [
+				'id' => 'wordpress_5_hack',
+				'title' => __( 'For launching of WordPress 5', 'jurassic-ninja' ),
+				'text' => __( 'Until ServerPilot starts installing WordPress 5, we need this hack', 'jurassic-ninja' ),
+				'placeholder' => '5.0',
+				'type' => 'checkbox',
+				'checked' => false,
+			],
+			'wordpress_5_latest' => [
+				'id' => 'wordpress_5_latest',
+				'title' => __( 'Latest tag for WordPress 5.0', 'jurassic-ninja' ),
+				'text' => __( 'Which version to run when wordpress-5 requested', 'jurassic-ninja' ),
+				'placeholder' => '5.0',
+				'value' => '5.0',
+			],
+		];
+		return array_merge( $fields, $field );
+	}, 10 );
+} );
+
+/**
+ * Updates WordPress to latest stable available for 5.0.
+ */
+function update_to_wordpress_5_latest() {
+	$wordpress_5_latest = settings( 'wordpress_5_latest', '5.0' );
+	$cmd = "wp core update --version=$wordpress_5_latest && wp core update-db";
+	add_filter( 'jurassic_ninja_feature_command', function ( $s ) use ( $cmd ) {
+		return "$s && $cmd";
+	} );
+}

--- a/features/wordpress-5-hack-until-serverpilot-updates.php
+++ b/features/wordpress-5-hack-until-serverpilot-updates.php
@@ -26,8 +26,8 @@ add_action( 'jurassic_ninja_admin_init', function() {
 		$field = [
 			'wordpress_5_hack' => [
 				'id' => 'wordpress_5_hack',
-				'title' => __( 'For launching of WordPress 5', 'jurassic-ninja' ),
-				'text' => __( 'Until ServerPilot starts installing WordPress 5, we need this hack', 'jurassic-ninja' ),
+				'title' => __( 'Force launching of WordPress 5', 'jurassic-ninja' ),
+				'text' => __( 'Until ServerPilot starts installing WordPress 5, we need this hack.', 'jurassic-ninja' ),
 				'placeholder' => '5.0',
 				'type' => 'checkbox',
 				'checked' => false,

--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -3,7 +3,7 @@
 /*
  * Plugin Name: Jurassic Ninja
  * Description: Launch ephemeral instances of WordPress + Jetpack using ServerPilot and an Ubuntu Box.
- * Version: 4.6
+ * Version: 4.7
  * Author: Automattic
  **/
 

--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -72,6 +72,7 @@ function require_feature_files() {
 		'/features/gutenberg-master.php',
 		'/features/gutenberg-nightly.php',
 		'/features/wordpress-4.php',
+		'/features/wordpress-5-hack-until-serverpilot-updates.php',
 	];
 
 	$available_features = apply_filters( 'jurassic_ninja_available_features', $available_features );


### PR DESCRIPTION
Not sure yet but it may be the case that ServerPilot takes some time before installing WordPress 5.0 even after it's released as stable. 

If that happens, this hack will help.

#### Changes introduced by this PR

* Provides a checkbox among Jurassic Ninja settings to force installation of WordPress 5.0.
* Bumps plugin verstion to 4.7