### PR TITLE
Fix Gutenpack script url path

### DIFF
--- a/features/gutenpack.php
+++ b/features/gutenpack.php
@@ -50,7 +50,7 @@ add_action( 'jurassic_ninja_init', function() {
 } );
 
 function add_gutenpack( $branch, $jetpack_dir = 'jetpack' ) {
-	$cmd = 'curl https://raw.githubusercontent.com/Automattic/jurassic.ninja/fix/gutenpack-build/bin/build-gutenpack.sh --output build-gutenpack.sh'
+	$cmd = 'curl https://raw.githubusercontent.com/Automattic/jurassic.ninja/master/bin/build-gutenpack.sh --output build-gutenpack.sh'
 		. " && source build-gutenpack.sh $branch $jetpack_dir";
 	add_filter( 'jurassic_ninja_feature_command', function ( $s ) use ( $cmd ) {
 		return "$s && $cmd";

--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -3,7 +3,7 @@
 /*
  * Plugin Name: Jurassic Ninja
  * Description: Launch ephemeral instances of WordPress + Jetpack using ServerPilot and an Ubuntu Box.
- * Version: 4.7.1
+ * Version: 4.7.2
  * Author: Automattic
  **/
 


### PR DESCRIPTION
This feature broke when the branch of #147 was deleted as the path pointed to the branch and not master.

* Fixes path
* Bumps plugin version to 4.7.2