### PR TITLE
Add PHP 7.3 to the version matrix for shortlived sites and make sites default to PHP 7.2

### DIFF
--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -3,7 +3,7 @@
 /*
  * Plugin Name: Jurassic Ninja
  * Description: Launch ephemeral instances of WordPress + Jetpack using ServerPilot and an Ubuntu Box.
- * Version: 4.8
+ * Version: 4.9
  * Author: Automattic
  **/
 

--- a/lib/serverpilot-stuff.php
+++ b/lib/serverpilot-stuff.php
@@ -23,6 +23,7 @@ add_action( 'jurassic_ninja_init', function() {
 		// PHP does not support graceful "restart" so every php-pool gets closed
 		// each time ServerPilot needs to SIGUSR1 php for reloading configuration
 		$shortlife_php_versions_alternatives = [
+			'php7.3',
 			'php7.2',
 			'php7.0',
 			'php5.6',
@@ -105,7 +106,7 @@ function sp() {
  * Creates a PHP app using ServerPilot's API
  * @param  String $name          The nickname of the App
  * @param  String $sysuserid     The System User that will "own" this App
- * @param  String $php_version   The PHP version for an App. Choose from php5.4, php5.5, php5.6, php7.0, or php7.1.
+ * @param  String $php_version   The PHP version for an App. Choose among php5.4, php5.5, php5.6, php7.0, php 7.2, or php 7.3
  * @param  Array  $domains       An array of domains that will be used in the webserver's configuration
  * @param  Array  $wordpress     An array containing the following keys: site_title , admin_user , admin_password , and admin_email
  * @return Object                An object with the new app data.

--- a/lib/serverpilot-stuff.php
+++ b/lib/serverpilot-stuff.php
@@ -34,7 +34,7 @@ add_action( 'jurassic_ninja_init', function() {
 			$php_version = $shortlife_php_versions_alternatives[ array_rand( $shortlife_php_versions_alternatives ) ];
 		}
 		if ( ! $features['shortlife'] && 'default' === $php_version ) {
-			$php_version = 'php7.0';
+			$php_version = 'php7.2';
 		}
 
 		debug( 'Launching %s on PHP version: %s', $domain, $php_version );

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <ruleset name="JurassicNinja">
 		<config name="minimum_supported_wp_version" value="4.7" />
-		<config name="testVersion" value="7.0-"/>
+		<config name="testVersion" value="7.2-"/>
 
 		<rule ref="PHPCompatibility" />
 		<rule ref="WordPress-Core" />
@@ -31,3 +31,4 @@
 		<exclude-pattern>/tests/*</exclude-pattern>
 		<exclude-pattern>/vendor/*</exclude-pattern>
 </ruleset>
+


### PR DESCRIPTION
Fixed #156