### PR TITLE
Add ability to launch with pregenerated content

### DIFF
--- a/features/content.php
+++ b/features/content.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace jn;
+
+add_action( 'jurassic_ninja_init', function() {
+	$defaults = [
+		'content' => false,
+	];
+
+	add_action( 'jurassic_ninja_add_features_before_auto_login', function( &$app = null, $features, $domain ) use ( $defaults ) {
+		$features = array_merge( $defaults, $features );
+		if ( $features['content'] ) {
+			debug( '%s: Adding pre-generated content', $domain );
+			add_content();
+		}
+	}, 1, 3 );
+
+	add_filter( 'jurassic_ninja_rest_create_request_features', function( $features, $json_params ) {
+		if ( isset( $json_params['content'] ) ) {
+			$features['content'] = $json_params['content'];
+		}
+		return $features;
+	}, 10, 2 );
+} );
+
+function add_content() {
+	$cmd = 'wget https://github.com/manovotny/wptest/archive/master.zip'
+		. ' && unzip master.zip'
+		. ' && echo "$(pwd) y $(pwd)/wptest-master/wptest.xml" | wptest-master/wptest-cli-install.sh';
+	add_filter( 'jurassic_ninja_feature_command', function ( $s ) use ( $cmd ) {
+		return "$s && $cmd";
+	} );
+}

--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -3,7 +3,7 @@
 /*
  * Plugin Name: Jurassic Ninja
  * Description: Launch ephemeral instances of WordPress + Jetpack using ServerPilot and an Ubuntu Box.
- * Version: 4.9
+ * Version: 4.10
  * Author: Automattic
  **/
 

--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -61,6 +61,7 @@ function add_auto_login( $password, $sysuser ) {
 function require_feature_files() {
 	$available_features = [
 		'/features/logged-in-user-email-address.php',
+		'/features/content.php',
 		'/features/multisite.php',
 		'/features/ssl.php',
 		'/features/plugins.php',


### PR DESCRIPTION
Introduces the feature `content` so the site is launched with content.

This is a very basic and kickoff-like implementation, using sample content that I found on http://wptest.io/

Was about to drop the intent, but then realized that the dataset took Jetpack in account (creating galleries for battletesting "Tiled galleries") and actually suggests installing Jetpack. 
