### PR TITLE
Add ability to launch a site with WP Job Manager, WP Super Cache, and /or Crowdsignal.

### DIFF
--- a/features/plugins.php
+++ b/features/plugins.php
@@ -21,6 +21,7 @@ add_action( 'jurassic_ninja_init', function() {
 		'wp-downgrade' => 'WP Downgrade',
 		'wp-log-viewer' => 'WP Log Viewer',
 		'wp-rollback' => 'WP Rollback',
+		'crowdsignal' => 'Crowdsignal',
 	];
 	// Set all defaults to false.
 	// Will probably add a filter here.
@@ -31,6 +32,14 @@ add_action( 'jurassic_ninja_init', function() {
 	add_action( 'jurassic_ninja_add_features_before_auto_login', function( &$app = null, $features, $domain ) use ( $defaults, $whitelist ) {
 		$features = array_merge( $defaults, $features );
 		foreach ( $whitelist as $slug => $name ) {
+			// Hack for Crowdsignal cause it's still referred to as polldaddy on the org repo
+			if ( 'crowdsignal' === $slug ) {
+				if ( isset( $features['crowdsignal'] ) && $features['crowdsignal'] ) {
+					debug( '%s: Adding %s', $domain, $name );
+					add_directory_plugin( 'polldaddy' );
+				}
+				continue;
+			}
 			if ( isset( $features[ $slug ] ) && $features[ $slug ] ) {
 				debug( '%s: Adding %s', $domain, $name );
 				add_directory_plugin( $slug );

--- a/features/plugins.php
+++ b/features/plugins.php
@@ -23,6 +23,7 @@ add_action( 'jurassic_ninja_init', function() {
 		'wp-job-manager' => 'WP Job Manager',
 		'wp-log-viewer' => 'WP Log Viewer',
 		'wp-rollback' => 'WP Rollback',
+		'wp-super-cache' => 'WP Super Cache',
 	];
 	// Set all defaults to false.
 	// Will probably add a filter here.

--- a/features/plugins.php
+++ b/features/plugins.php
@@ -14,14 +14,15 @@ add_action( 'jurassic_ninja_init', function() {
 		'classic-editor' => 'Classic Editor',
 		'code-snippets' => 'Code Snippets',
 		'config-constants' => 'Config Constants',
+		'crowdsignal' => 'Crowdsignal',
 		'gutenberg' => 'Gutenberg',
 		'jetpack' => 'Jetpack',
 		'woocommerce' => 'WooCommerce',
 		'wordpress-beta-tester' => 'WordPress Beta Tester Plugin',
 		'wp-downgrade' => 'WP Downgrade',
+		'wp-job-manager' => 'WP Job Manager',
 		'wp-log-viewer' => 'WP Log Viewer',
 		'wp-rollback' => 'WP Rollback',
-		'crowdsignal' => 'Crowdsignal',
 	];
 	// Set all defaults to false.
 	// Will probably add a filter here.

--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -3,7 +3,7 @@
 /*
  * Plugin Name: Jurassic Ninja
  * Description: Launch ephemeral instances of WordPress + Jetpack using ServerPilot and an Ubuntu Box.
- * Version: 4.11
+ * Version: 4.12
  * Author: Automattic
  **/
 


### PR DESCRIPTION
* Adds the params are `crowdsignal`, `wp-super-cache`, `wp-job-manager`.
* Bumps to 4.12