### PR TITLE
Faviocn: Make sure that we use the root relative url

### DIFF
--- a/jurassicninja.js
+++ b/jurassicninja.js
@@ -247,7 +247,7 @@ function favicon_update_colour( colour ) {
         if ( ['i1.wp.com', 'i2.wp.com','i3.wp.com', 'i4.wp.com'].indexOf( location.host ) >= 0 ) {
            var pathSplit = location.pathname.split( '/' );
            pathSplit.splice( 0, 2); // removes the domain part
-           img.src = pathSplit.join( '/' );
+           img.src = '/' + pathSplit.join( '/' ); 
         } else {
             img.src = favicon.href;
         }


### PR DESCRIPTION
Fixes the function that is suppose to generate the favicon by making sure the the root path is being used. 

I tested this by running the function in the dev console and the result worked on the production. 

cc: @oskosk 