### PR TITLE
Replace URLS after content import

### DIFF
--- a/features/content.php
+++ b/features/content.php
@@ -11,7 +11,7 @@ add_action( 'jurassic_ninja_init', function() {
 		$features = array_merge( $defaults, $features );
 		if ( $features['content'] ) {
 			debug( '%s: Adding pre-generated content', $domain );
-			add_content();
+			add_content( $domain, $features );
 		}
 	}, 1, 3 );
 
@@ -23,10 +23,13 @@ add_action( 'jurassic_ninja_init', function() {
 	}, 10, 2 );
 } );
 
-function add_content() {
+function add_content( $domain, $features ) {
+	$schema = ( isset( $features['ssl'] ) && $features['ssl'] ) ? 'https://' : 'http://';
+	$url = $schema . $domain;
 	$cmd = 'wget https://github.com/manovotny/wptest/archive/master.zip'
 		. ' && unzip master.zip'
-		. ' && echo "$(pwd) y $(pwd)/wptest-master/wptest.xml" | wptest-master/wptest-cli-install.sh';
+		. ' && echo "$(pwd) y $(pwd)/wptest-master/wptest.xml" | wptest-master/wptest-cli-install.sh'
+		. " && wp search-replace http://wpthemetestdata.wordpress.com $url";
 	add_filter( 'jurassic_ninja_feature_command', function ( $s ) use ( $cmd ) {
 		return "$s && $cmd";
 	} );

--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -3,7 +3,7 @@
 /*
  * Plugin Name: Jurassic Ninja
  * Description: Launch ephemeral instances of WordPress + Jetpack using ServerPilot and an Ubuntu Box.
- * Version: 4.13.1
+ * Version: 4.13.2
  * Author: Automattic
  **/
 

--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -61,9 +61,9 @@ function add_auto_login( $password, $sysuser ) {
 function require_feature_files() {
 	$available_features = [
 		'/features/logged-in-user-email-address.php',
-		'/features/content.php',
 		'/features/multisite.php',
 		'/features/ssl.php',
+		'/features/content.php',
 		'/features/plugins.php',
 		'/features/jetpack-beta.php',
 		'/features/wc-smooth-generator.php',


### PR DESCRIPTION
When launching a site with sample content, the site URLs on the posts GUIDs remain the same as the sample content ones. 

This change makes them be replaced by the Jurassic Ninja site's own URL.