### PR TITLE
Update the commands in the build-gutenpack.sh script 

### DIFF
--- a/bin/build-gutenpack.sh
+++ b/bin/build-gutenpack.sh
@@ -13,7 +13,8 @@ echo "Getting wp-calypso branch $CALYPSO_BRANCH"
 cd $HOME \
 && git clone https://github.com/automattic/wp-calypso --depth=1 -b "$CALYPSO_BRANCH" \
 && cd wp-calypso \
-&& npx lerna bootstrap --ci \
+&& npm ci \
+&& npm run build-packages \
 && echo "Building jetpack-editor for wp-calypso branch $CALYPSO_BRANCH" \
 && npm run sdk -- gutenberg client/gutenberg/extensions/presets/jetpack \
   --output-dir=$HOME/apps/$USER/public/wp-content/plugins/"$JETPACK_DIRNAME"/_inc/blocks \

--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -3,7 +3,7 @@
 /*
  * Plugin Name: Jurassic Ninja
  * Description: Launch ephemeral instances of WordPress + Jetpack using ServerPilot and an Ubuntu Box.
- * Version: 4.13.1
+ * Version: 4.13.2
  * Author: Automattic
  **/
 


### PR DESCRIPTION
The commands to build gutenpack changed in Calypso.

This PR updates the commands and bumps version to 4.13.2

#### Why ?

![image](https://user-images.githubusercontent.com/746152/53275797-39626c00-36db-11e9-92f2-0cbe65af1790.png)
