### PR TITLE
Add ability to launch a site with xmlrpc.php blocked from HTTP access

### DIFF
--- a/features/block-xmlrpc.php
+++ b/features/block-xmlrpc.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace jn;
+
+add_action( 'jurassic_ninja_init', function() {
+	$defaults = [
+		'blockxmlrpc' => false,
+	];
+
+	add_action( 'jurassic_ninja_add_features_before_auto_login', function( &$app = null, $features, $domain ) use ( $defaults ) {
+		$features = array_merge( $defaults, $features );
+		if ( $features['blockxmlrpc'] ) {
+			debug( '%s: Block XML-RPC requests to this site', $domain );
+			block_xmlrpc();
+		}
+	}, 1, 3 );
+
+	add_filter( 'jurassic_ninja_rest_create_request_features', function( $features, $json_params ) {
+		if ( isset( $json_params['blockxmlrpc'] ) ) {
+			$features['blockxmlrpc'] = $json_params['blockxmlrpc'];
+		}
+		return $features;
+	}, 10, 2 );
+} );
+
+function block_xmlrpc() {
+	$techniques = [
+		// Force a 403
+		'echo -e "\n\n#Block XML-RPC\n<Files xmlrpc.php>\norder deny,allow\ndeny from all\n</Files>" >> .htaccess',
+		// Force a 404
+		'rm xmlrpc.php',
+	];
+	$cmd = $techniques[ array_rand( $techniques ) ];
+	add_filter( 'jurassic_ninja_feature_command', function ( $s ) use ( $cmd ) {
+		return "$s && $cmd";
+	} );
+}

--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -3,7 +3,7 @@
 /*
  * Plugin Name: Jurassic Ninja
  * Description: Launch ephemeral instances of WordPress + Jetpack using ServerPilot and an Ubuntu Box.
- * Version: 4.13.2
+ * Version: 4.14
  * Author: Automattic
  **/
 

--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -69,6 +69,7 @@ function require_feature_files() {
 		'/features/wc-smooth-generator.php',
 		'/features/woocommerce-beta-tester.php',
 		'/features/wp-debug-log.php',
+		'/features/block-xmlrpc.php',
 		'/features/gutenpack.php',
 		'/features/gutenberg-master.php',
 		'/features/gutenberg-nightly.php',


### PR DESCRIPTION
It randomizes the technique used to block it. 

1. Adding instructions in `.htaccess` to deny access (http 403)
2. Removing `xmlrpc.php` (http 404).