### PR TITLE
Set home and siteurl options on launch for sites using SSL

### DIFF
--- a/features/ssl.php
+++ b/features/ssl.php
@@ -31,6 +31,8 @@ add_action( 'jurassic_ninja_init', function() {
 					// phpcs:enable
 					throw new \Exception( 'Error enabling SSL: ' . $response->get_error_message() );
 				}
+				debug( '%s: Setting home and siteurl options', $domain );
+				set_home_and_site_url( $domain );
 			}
 		}
 	}, 10, 3 );
@@ -84,3 +86,12 @@ add_action( 'jurassic_ninja_admin_init', function() {
 		return $options_page;
 	} );
 } );
+
+function set_home_and_site_url( $domain ) {
+	$cmd = "wp option set siteurl https://$domain"
+		. " && wp option set home https://$domain";
+
+	add_filter( 'jurassic_ninja_feature_command', function ( $s ) use ( $cmd ) {
+		return "$s && $cmd";
+	} );
+}

--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -3,7 +3,7 @@
 /*
  * Plugin Name: Jurassic Ninja
  * Description: Launch ephemeral instances of WordPress + Jetpack using ServerPilot and an Ubuntu Box.
- * Version: 4.15.1
+ * Version: 4.15.2
  * Author: Automattic
  **/
 


### PR DESCRIPTION
ServerPilot stopped putting the magic calculation of a site's URL scheme in wp-config.php


```
define('SP_REQUEST_URL', ($_SERVER['HTTPS'] ? 'https://' : 'http://') . $_SERVER['HTTP_HOST']);

define('WP_SITEURL', SP_REQUEST_URL);
define('WP_HOME', SP_REQUEST_URL);
```

This PR makes sure we set the `siteurl` and `home` options after launching the site with SSL.

This was causing problems with Jetack's signature.