### PR TITLE
Remove old PHP versions and default to PHP 7.3

### DIFF
--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -3,7 +3,7 @@
 /*
  * Plugin Name: Jurassic Ninja
  * Description: Launch ephemeral instances of WordPress + Jetpack using ServerPilot and an Ubuntu Box.
- * Version: 4.18
+ * Version: 4.19
  * Author: Automattic
  **/
 

--- a/lib/serverpilot-stuff.php
+++ b/lib/serverpilot-stuff.php
@@ -27,8 +27,6 @@ add_action( 'jurassic_ninja_init', function() {
 			'php7.2',
 			'php7.0',
 			'php5.6',
-			'php5.5',
-			'php5.4',
 		];
 		if ( $features['shortlife'] && 'default' === $php_version ) {
 			$php_version = $shortlife_php_versions_alternatives[ array_rand( $shortlife_php_versions_alternatives ) ];

--- a/lib/serverpilot-stuff.php
+++ b/lib/serverpilot-stuff.php
@@ -32,7 +32,7 @@ add_action( 'jurassic_ninja_init', function() {
 			$php_version = $shortlife_php_versions_alternatives[ array_rand( $shortlife_php_versions_alternatives ) ];
 		}
 		if ( ! $features['shortlife'] && 'default' === $php_version ) {
-			$php_version = 'php7.2';
+			$php_version = 'php7.3';
 		}
 
 		debug( 'Launching %s on PHP version: %s', $domain, $php_version );


### PR DESCRIPTION
Latest WordPress (5.2) bails on running over PHP versions earlier than 5.6 and the site health feature just recommends to upgrade to 7.3