### PR TITLE
Check if the selected branch is not empty too for defaulting to master when jetpack-beta requested

### DIFF
--- a/features/jetpack-beta.php
+++ b/features/jetpack-beta.php
@@ -39,7 +39,7 @@ add_action( 'jurassic_ninja_init', function() {
 	} );
 
 	add_filter( 'jurassic_ninja_rest_create_request_features', function( $features, $json_params ) {
-		$branch = isset( $json_params['branch'] ) ? $json_params['branch'] : 'master';
+		$branch = isset( $json_params['branch'] ) && $json_params['branch'] ? $json_params['branch'] : 'master';
 		if ( isset( $json_params['jetpack-beta'] ) && $json_params['jetpack-beta'] ) {
 			$url = get_jetpack_beta_url( $branch );
 

--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -3,7 +3,7 @@
 /*
  * Plugin Name: Jurassic Ninja
  * Description: Launch ephemeral instances of WordPress + Jetpack using ServerPilot and an Ubuntu Box.
- * Version: 4.19
+ * Version: 4.19.1
  * Author: Automattic
  **/
 


### PR DESCRIPTION
Currently if we send an empty value in `branch` when `jetpack-beta` is requested, JN tries to match that empty value to available matches and fails to launch