### PR TITLE
Add ability to install the jetpack debug helper plugin on launch

### DIFF
--- a/docs/specialops.md
+++ b/docs/specialops.md
@@ -1,3 +1,8 @@
+# SpecialOps Page
+
+Similarly to the `/create` page, a `/specialops` page can be created which gives control over site configuration.
+
+Recommended `/specialops` page content:
 ```
 <!-- wp:paragraph {"className":"has-border","textColor":"primary","fontSize":"small"} -->
 <p class="has-border has-primary-color has-text-color has-small-font-size">IMPORTANT: Jurassic Ninja is meant to be used as an internal tool only. It’s not branded (there’s neither an intention to) and is not set up to scale to mass public use. For more questions ask in #jurassic-ninja Slack.</p>

--- a/docs/specialops.md
+++ b/docs/specialops.md
@@ -1,8 +1,3 @@
-# SpecialOps Page
-
-Similarly to the `/create` page, a `/specialops` page can be created which gives control over site configuration.
-
-Recommended `/specialops` page content:
 ```
 <!-- wp:paragraph {"className":"has-border","textColor":"primary","fontSize":"small"} -->
 <p class="has-border has-primary-color has-text-color has-small-font-size">IMPORTANT: Jurassic Ninja is meant to be used as an internal tool only. It’s not branded (there’s neither an intention to) and is not set up to scale to mass public use. For more questions ask in #jurassic-ninja Slack.</p>
@@ -71,6 +66,9 @@ Recommended `/specialops` page content:
 </li>
 <li>
 <div class="checkbox"><label><input type="checkbox" data-feature="zero-bs-crm">&nbsp;Include Jetpack CRM</label></div>
+</li>
+<li>
+<div class="checkbox"><label><input type="checkbox" data-feature="jetpack-debug-helper">&nbsp;Include Jetpack Debug Helper</label></div>
 </li>
 </ul>
 <!-- /wp:html --></div>

--- a/features/jetpack-debug-helper.php
+++ b/features/jetpack-debug-helper.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace jn;
+
+define( 'JETPACK_DEBUG_HELPER_PLUGIN_MASTER_URL', 'https://github.com/automattic/jetpack-debug-helper/archive/master.zip' );
+
+add_action( 'jurassic_ninja_init', function () {
+	$defaults = [
+		'jetpack-debug-helper' => false,
+	];
+
+	add_action( 'jurassic_ninja_add_features_before_auto_login', function ( &$app, $features, $domain ) use ( $defaults ) {
+		$features = array_merge( $defaults, $features );
+		if ( $features['jetpack-debug-helper'] ) {
+			debug( '%s: Adding Jetpack Debug Helper Plugin (master branch)', $domain );
+			add_jetpack_debug_helper_master_plugin();
+		}
+	}, 10, 3 );
+
+	add_filter( 'jurassic_ninja_rest_create_request_features', function ( $features, $json_params ) {
+		if ( isset( $json_params['jetpack-debug-helper'] ) ) {
+			$features['jetpack-debug-helper'] = $json_params['jetpack-debug-helper'];
+		}
+
+		return $features;
+	}, 10, 2 );
+} );
+
+/**
+ * Installs and activates Jetpack Debug plugin (master branch) on the site.
+ */
+function add_jetpack_debug_helper_master_plugin() {
+	$jetpack_debug_helper_plugin_master_url = JETPACK_DEBUG_HELPER_PLUGIN_MASTER_URL;
+	$cmd                           = "wp plugin install $jetpack_debug_helper_plugin_master_url --activate";
+	add_filter( 'jurassic_ninja_feature_command', function ( $s ) use ( $cmd ) {
+		return "$s && $cmd";
+	} );
+}

--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -3,7 +3,7 @@
 /*
  * Plugin Name: Jurassic Ninja
  * Description: Launch ephemeral instances of WordPress + Jetpack using ServerPilot and an Ubuntu Box.
- * Version: 5.5.1
+ * Version: 5.6
  * Author: Automattic
  **/
 

--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -104,6 +104,7 @@ function require_feature_files() {
 		'/features/wc-smooth-generator.php',
 		'/features/woocommerce-beta-tester.php',
 		'/features/jetpack-crm-master.php',
+		'/features/jetpack-debug-helper.php',
 		'/features/wp-debug-log.php',
 		'/features/block-xmlrpc.php',
 		'/features/language.php',


### PR DESCRIPTION
By launching with `create/?jetpack-debug-helper&shortlived` you can have the [Jetpack Debug Helper](https://dev.jurassic.ninja/create/?jetpack-debug-helper&shortlived) installed and active.

* Bumps JN version to 5.6
* Upddates specialops.md to include the checkbox for Jetpack Debu Helper