### PR TITLE
Add ability to install Client Example plugin on launch

### DIFF
--- a/docs/specialops.md
+++ b/docs/specialops.md
@@ -76,6 +76,9 @@ Recommended `/specialops` page content:
 <li>
 <div class="checkbox"><label><input type="checkbox" data-feature="jetpack-debug-helper">&nbsp;Include Jetpack Debug Helper</label></div>
 </li>
+<li>
+<div class="checkbox"><label><input type="checkbox" data-feature="client-example">&nbsp;Include Client Example</label></div>
+</li>
 </ul>
 <!-- /wp:html --></div>
 <!-- /wp:column -->

--- a/features/client-example.php
+++ b/features/client-example.php
@@ -31,7 +31,16 @@ add_action( 'jurassic_ninja_init', function () {
  */
 function add_client_example_master_plugin() {
 	$client_example_plugin_master_url = CLIENT_EXAMPLE_PLUGIN_MASTER_URL;
-	$cmd                              = "wp plugin install $client_example_plugin_master_url --activate";
+
+	/**
+	 * We install the plugin but don't activate until dependencies are there or it will fail
+	 */
+	$cmd = "wp plugin install $client_example_plugin_master_url"
+		. ' && pushd . && cd wp-content/plugins/client-example'
+		. ' && composer install --no-dev'
+		. ' && wp plugin activate client-example'
+		. ' && popd';
+
 	add_filter( 'jurassic_ninja_feature_command', function ( $s ) use ( $cmd ) {
 		return "$s && $cmd";
 	} );

--- a/features/client-example.php
+++ b/features/client-example.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace jn;
+
+define( 'CLIENT_EXAMPLE_PLUGIN_MASTER_URL', 'https://github.com/Automattic/client-example/archive/master.zip' );
+
+add_action( 'jurassic_ninja_init', function () {
+	$defaults = [
+		'client-example' => false,
+	];
+
+	add_action( 'jurassic_ninja_add_features_before_auto_login', function ( &$app, $features, $domain ) use ( $defaults ) {
+		$features = array_merge( $defaults, $features );
+		if ( $features['client-example'] ) {
+			debug( '%s: Adding Client Example Plugin (master branch)', $domain );
+			add_client_example_master_plugin();
+		}
+	}, 10, 3 );
+
+	add_filter( 'jurassic_ninja_rest_create_request_features', function ( $features, $json_params ) {
+		if ( isset( $json_params['client-example'] ) ) {
+			$features['client-example'] = $json_params['client-example'];
+		}
+
+		return $features;
+	}, 10, 2 );
+} );
+
+/**
+ * Installs and activates Jetpack Debug plugin (master branch) on the site.
+ */
+function add_client_example_master_plugin() {
+	$client_example_plugin_master_url = CLIENT_EXAMPLE_PLUGIN_MASTER_URL;
+	$cmd                              = "wp plugin install $client_example_plugin_master_url --activate";
+	add_filter( 'jurassic_ninja_feature_command', function ( $s ) use ( $cmd ) {
+		return "$s && $cmd";
+	} );
+}

--- a/features/jetpack-debug-helper.php
+++ b/features/jetpack-debug-helper.php
@@ -13,7 +13,7 @@ add_action( 'jurassic_ninja_init', function () {
 		$features = array_merge( $defaults, $features );
 		if ( $features['jetpack-debug-helper'] ) {
 			debug( '%s: Adding Jetpack Debug Helper Plugin (master branch)', $domain );
-			add_jetpack_debug_helper_master_plugin();
+			add_client_example_master_plugin();
 		}
 	}, 10, 3 );
 

--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -3,7 +3,7 @@
 /*
  * Plugin Name: Jurassic Ninja
  * Description: Launch ephemeral instances of WordPress + Jetpack using ServerPilot and an Ubuntu Box.
- * Version: 5.8
+ * Version: 5.9
  * Author: Automattic
  **/
 

--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -105,6 +105,7 @@ function require_feature_files() {
 		'/features/woocommerce-beta-tester.php',
 		'/features/jetpack-crm-master.php',
 		'/features/jetpack-debug-helper.php',
+		'/features/client-example.php',
 		'/features/wp-debug-log.php',
 		'/features/block-xmlrpc.php',
 		'/features/language.php',


### PR DESCRIPTION
Client Example is a plugin often used to test and debug Jetpack connection: https://github.com/Automattic/client-example
This PR adds the plugin to the "specialops" page, so it could be automatically installed on the sites.