### PR TITLE
Bringing back the Jetpack Debug Helper

### DIFF
--- a/features/jetpack-debug-helper.php
+++ b/features/jetpack-debug-helper.php
@@ -13,7 +13,7 @@ add_action( 'jurassic_ninja_init', function () {
 		$features = array_merge( $defaults, $features );
 		if ( $features['jetpack-debug-helper'] ) {
 			debug( '%s: Adding Jetpack Debug Helper Plugin (master branch)', $domain );
-			add_client_example_master_plugin();
+			add_jetpack_debug_helper_master_plugin();
 		}
 	}, 10, 3 );
 

--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -3,7 +3,7 @@
 /*
  * Plugin Name: Jurassic Ninja
  * Description: Launch ephemeral instances of WordPress + Jetpack using ServerPilot and an Ubuntu Box.
- * Version: 5.9
+ * Version: 5.9.1
  * Author: Automattic
  **/
 


### PR DESCRIPTION
I accidentally overwritten some of the Jetpack Debug Helper initialization code in the "Client Example" PR: #212.

This PR is:
- fixing the problem (reverting that overwritten code)
- bumping the version number