### PR TITLE
Additional PHP 8 compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,14 @@
 {
 	"require": {
 		"daverogers/serverpilot-php": "1.*",
-		"nubs/random-name-generator": "^2.2"
+		"nubs/random-name-generator": "^2.2",
+		"php": "~7.1 || 8.*"
 	},
 	"require-dev": {
 		"automattic/jetpack-codesniffer": "^2.0",
+		"brain/monkey": "^2.6",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-		"phpunit/phpunit": "^6.4",
+		"phpunit/phpunit": "7.* || 8.*",
 		"squizlabs/php_codesniffer": "*"
 	},
 	"scripts": {

--- a/features/jetpack-licensing.php
+++ b/features/jetpack-licensing.php
@@ -347,7 +347,7 @@ add_action(
 /**
  * Register a shortcode which renders Jetpack Licensing controls suitable for SpecialOps usage.
  */
-add_shortcode(
+\add_shortcode(
 	'jn_jetpack_products_list',
 	function () {
 		$families = get_product_families();

--- a/tests/lib/class-teststuff.php
+++ b/tests/lib/class-teststuff.php
@@ -1,20 +1,12 @@
 <?php
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
 
-require_once( dirname( __FILE__ ) . '/../../vendor/autoload.php' );
-
-use \PHPUnit\Framework\TestCase;
+define( 'PLUGIN_DIR', dirname( __FILE__ ) . '/../..' );
+require_once dirname( __FILE__ ) . '/../../vendor/autoload.php';
 
 define( 'ABSPATH', 'true' );
-require_once( dirname( __FILE__ ) . '/../../lib/stuff.php' );
-
-
-function apply_filters() {
-
-}
-
-function add_action() {
-
-}
 
 function wp_generate_password() {
 	return '1231231231231';
@@ -23,6 +15,21 @@ function wp_generate_password() {
  * @covers Stuff
  */
 final class TestStuff extends TestCase {
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		Functions\when( 'add_shortcode' )
+			->justReturn( true );
+
+		require_once dirname( __FILE__ ) . '/../../lib/stuff.php';
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
 	public function testCanCreateSlug() {
 
 		$this->assertEquals( 'dirty-combo', jn\create_slug( 'Dirty Combo' ) );
@@ -30,15 +37,15 @@ final class TestStuff extends TestCase {
 
 	public function testCanGenerateRandomPassword() {
 
-		$this->assertInternalType( 'string',jn\generate_random_password() );
+		$this->assertIsString( 'string', jn\generate_random_password() );
 		$this->assertEquals( 13, strlen( jn\generate_random_password() ) );
 	}
 
 	public function testCanFigureOutMainDomain() {
-		$domains = [
+		$domains = array(
 			'dangerous-voldemort.jurassic.ninja',
 			'*.dangerous-voldemort.jurassic.ninja',
-		];
-		$this->assertEquals( 'dangerous-voldemort.jurassic.ninja', jn\figure_out_main_domain( $domains ));
+		);
+		$this->assertEquals( 'dangerous-voldemort.jurassic.ninja', jn\figure_out_main_domain( $domains ) );
 	}
 }


### PR DESCRIPTION
Just a few items needed for composer to install it on PHP 8.

* Sets PHP version bounds.
* Updates to phpunit 7 or 8, instead of 6.
* Reworks the tests a bit to be happy.
* Use Brain/Monkey for mocks.
* Fix an error in the licensing code that slid through at some point.﻿
