### PR TITLE
Disconnect Jetpack on purge

### DIFF
--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -29,6 +29,7 @@ function init() {
 	require_once __DIR__ . '/lib/cron-stuff.php';
 	require_once __DIR__ . '/lib/db-stuff.php';
 	require_once __DIR__ . '/lib/settings-stuff.php';
+	require_once __DIR__ . '/lib/jetpack-stuff.php';
 	require_once __DIR__ . '/lib/stuff.php';
 
 	if ( is_cli_running() ) {

--- a/lib/jetpack-stuff.php
+++ b/lib/jetpack-stuff.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Does stuff for Jetpack.
+ *
+ * @package jurassic-ninja
+ */
+
+namespace jn;
+
+// Disconnect Jetpack upon purge.
+add_action(
+	'jurassic_ninja_purge_site',
+	function ( $site, $user ) {
+		$command = "cd ~/apps/{$user->name}/public && wp jetpack disconnect";
+		debug( '%s: Running commands %s', $user->id, $command );
+
+		$return = run_command_on_behalf( $site['username'], $site['password'], $command );
+
+		if ( is_wp_error( $return ) ) {
+			debug(
+				'There was an error disconnecting Jetpack for user %s: (%s) - %s',
+				$user->id,
+				$return->get_error_code(),
+				$return->get_error_message()
+			);
+		}
+	}
+);


### PR DESCRIPTION
See #118

This would disconnect Jetpack with the JN site is being purged. To fully complete 118, it would need to cancel the plan. There isn't baked-in Jetpack-side functionality for that at this time.﻿
