### PR TITLE
Update woocommerce-beta-tester plugin url

### DIFF
--- a/features/woocommerce-beta-tester.php
+++ b/features/woocommerce-beta-tester.php
@@ -7,7 +7,7 @@
 
 namespace jn;
 
-define( 'WOOCOMMERCE_BETA_TESTER_PLUGIN_URL', 'https://github.com/woocommerce/woocommerce-beta-tester/archive/master.zip' );
+define( 'WOOCOMMERCE_BETA_TESTER_PLUGIN_URL', 'https://github.com/woocommerce/woocommerce-beta-tester/archive/refs/heads/trunk.zip' );
 
 add_action(
 	'jurassic_ninja_init',

--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Jurassic Ninja
  * Description: Launch ephemeral instances of WordPress + Jetpack using ServerPilot and an Ubuntu Box.
- * Version: 5.9.1
+ * Version: 5.9.2
  * Author: Automattic
  *
  * @package jurassic-ninja


### PR DESCRIPTION
https://github.com/woocommerce/woocommerce-beta-tester/archive/master.zip is returning a 404 for me but https://github.com/woocommerce/woocommerce-beta-tester/archive/refs/heads/trunk.zip works—which I copied from the "Download ZIP" option on the GitHub repo main page.