### PR TITLE
Update docker-compose.yml paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ Create a new page and call it "Specialops". You can use the contents of [special
 
 3. Configure the top-domain on which this is going to create sites.
 
-### Using a docker container for testing
+### Using a Docker container for testing
 
-It may be convenient to use this plugin using a docker container for local development.
+It may be convenient to test this plugin using the [Jetpack monorepo Docker setup](https://github.com/Automattic/jetpack/blob/master/tools/docker/README.md).
 
-Make sure that [docker is installed and running](https://docs.docker.com/install/) before proceeding.
+Make sure that your copy of this repo and the Jetpack monorepo are stored within the same directory, and that [Docker is installed and running](https://docs.docker.com/install/) before proceeding.
 
 1. Create `jndb` folder in the root of this source code, where WordPress DB will be stored:
 
@@ -95,15 +95,15 @@ Make sure that [docker is installed and running](https://docs.docker.com/install
 mkdir ./jndb
 ```
 
-1. create and run docker containers:
+2. create and run Docker containers:
 
 ```sh
 docker-compose up
 ```
 
-1. Navigate to <http://localhost> to create WordPress site, Activate Jurassic Ninja plugin. Other plugins are optional
+3. Navigate to <http://localhost> to create WordPress site, Activate Jurassic Ninja plugin. Other plugins are optional
 
-1. Setup Jurassic Ninja plugin as menitioned above
+4. Setup Jurassic Ninja plugin as mentioned above
 
 ### Gotchas
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,31 +11,31 @@ services:
     ports:
       - "${PORT_MYSQL:-3306}:3306"
     env_file:
-      - ../jetpack/docker/default.env
-      - ../jetpack/docker/.env
+      - ../jetpack/tools/docker/default.env
+      - ../jetpack/tools/docker/.env
 
   wordpress:
     container_name: jn_wordpress
     depends_on:
       - db
-    build: ../jetpack/docker
+    build: ../jetpack/tools/docker
     image: jn_wordpress:localbuild
     ports:
       - "${PORT_WORDPRESS:-80}:80"
     env_file:
-      - ../jetpack/docker/default.env
-      - ../jetpack/docker/.env
+      - ../jetpack/tools/docker/default.env
+      - ../jetpack/tools/docker/.env
     environment:
       - HOST_PORT=${PORT_WORDPRESS}
       - WORDPRESS_DB_PASSWORD=wordpress
       - XDEBUG_CONFIG=_host=10.0.1.19
     volumes:
       - ../jetpack:/var/www/html/wp-content/plugins/jetpack
-      - ../jetpack/docker/wordpress:/var/www/html
-      - ../jetpack/docker/logs/apache2:/var/log/apache2
-      - ../jetpack/docker/logs/php:/var/log/php
-      - ../jetpack/docker/bin:/var/scripts
-      - ../jetpack/docker/wordpress-develop:/tmp/wordpress-develop
+      - ../jetpack/tools/docker/wordpress:/var/www/html
+      - ../jetpack/tools/docker/logs/apache2:/var/log/apache2
+      - ../jetpack/tools/docker/logs/php:/var/log/php
+      - ../jetpack/tools/docker/bin:/var/scripts
+      - ../jetpack/tools/docker/wordpress-develop:/tmp/wordpress-develop
       - ../errors:/var/www/html/wp-content/plugins/errors
       - ./:/var/www/html/wp-content/plugins/jurassic.ninja
       - ../jurassic.ninja-ext:/var/www/html/wp-content/plugins/jurassic.ninja-ext


### PR DESCRIPTION
As far as I can tell, the JN local dev setup is meant to work off of the JP Docker setup. Updating the paths in `docker-compose.yml` and having both repos sit under the same directory allowed `docker-compose up` to work for me.