### PR TITLE
Use stable JP Beta by default

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,13 @@
+5.11 / TBD
+==================
+
+  * Disconnect Jetpack upon site purge.
+
+5.10.1 / 2021-05-05
+==================
+
+  * Fixed WooCommerce Smooth Generator feature
+
 5.10 / 2021-04-20
 ==================
 

--- a/docs/specialops.md
+++ b/docs/specialops.md
@@ -30,7 +30,6 @@ Recommended `/specialops` page content:
 </li>
 <li style="min-width: 30%;">
 <div class="form-group"><label for="php_version">&nbsp;PHP version:</label><br><select class="form-control" name="php_version" data-feature="php_version">
-<option value="php5.4">PHP 5.4</option>
 <option value="php5.6">PHP 5.6</option>
 <option value="php7.0">PHP 7.0</option>
 <option value="php7.2">PHP 7.2</option>
@@ -60,7 +59,9 @@ Recommended `/specialops` page content:
 [jn_jetpack_products_list]
 </li>
 <li>
-<div class="checkbox"><label><input type="checkbox" data-feature="jetpack-beta">&nbsp;Include Jetpack Beta</label></div>
+<div class="checkbox"><label><input type="radio" name="jetpack-beta" value="stable" data-feature="jetpack-beta">&nbsp;Include Jetpack Beta</label></div>
+<div class="checkbox"><label><input type="radio" name="jetpack-beta" value="dev" data-feature="jetpack-beta-dev">&nbsp;Include Jetpack Beta (Bleeding Edge)</label></div>
+<div class="checkbox"><label><input type="radio" name="jetpack-beta" value="none">&nbsp;Do not include Jetpack Beta</label></div>
 </li>
 <li>
 <div class="form-group"><label for="jetpack_branch">Jetpack Branch:</label><br><input id="jetpack_branch" class="form-control" role="search" disabled="disabled" list="jetpack_branches" type="text" value="" placeholder="Requires Jetpack Beta plugin" data-feature="branch" aria-hidden="false"><br>

--- a/features/jetpack-beta.php
+++ b/features/jetpack-beta.php
@@ -36,7 +36,10 @@ add_action(
 				$features = array_merge( $defaults, $features );
 				if ( $features['jetpack-beta'] ) {
 					debug( '%s: Adding Jetpack Beta Tester Plugin', $domain );
-					add_jetpack_beta_plugin();
+					add_jetpack_beta_plugin( false );
+				} else if ( $features['jetpack-beta-dev'] ) {
+					debug( '%s: Adding Jetpack Beta Tester Plugin (Bleeding Edge)', $domain );
+					add_jetpack_beta_plugin( true );
 				}
 
 				if ( $features['branch'] ) {
@@ -114,9 +117,11 @@ add_action(
 
 /**
  * Installs and activates Jetpack Beta Tester plugin on the site.
+ *
+ * @param bool $dev Install bleeding edge version of the Jetpack Beta plugin.
  */
-function add_jetpack_beta_plugin() {
-	$jetpack_beta_plugin_url = JETPACK_BETA_PLUGIN_URL;
+function add_jetpack_beta_plugin( $dev = false ) {
+	$jetpack_beta_plugin_url = ( $dev ) ? JETPACK_BETA_PLUGIN_DEV_URL : JETPACK_BETA_PLUGIN_URL;
 	$cmd = "wp plugin install $jetpack_beta_plugin_url --activate";
 	add_filter(
 		'jurassic_ninja_feature_command',

--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -45,7 +45,7 @@ require_once __DIR__ . '/class-serverpilotprovisioner.php';
 
 define( 'REST_API_NAMESPACE', 'jurassic.ninja' );
 define( 'COMPANION_PLUGIN_URL', 'https://github.com/Automattic/companion/archive/master.zip' );
-define( 'JETPACK_BETA_PLUGIN_URL', 'https://github.com/Automattic/jetpack-beta/archive/master.zip' );
+define( 'JETPACK_BETA_PLUGIN_URL', 'https://github.com/Automattic/jetpack-beta/releases/latest/download/jetpack-beta.zip' );
 define( 'SUBDOMAIN_MULTISITE_HTACCESS_TEMPLATE_URL', 'https://gist.githubusercontent.com/oskosk/8cac852c793df5e4946463e2e55dfdd6/raw/a60ce4122a69c1dd36c623c9b999c36c9c8d3db8/gistfile1.txt' );
 define( 'SUBDIR_MULTISITE_HTACCESS_TEMPLATE_URL', 'https://gist.githubusercontent.com/oskosk/f5febd1bb65a2ace3d35feac949b47fd/raw/6ea8ffa013056f6793d3e8775329ec74d3304835/gistfile1.txt' );
 define( 'REGULAR_SITE_HTACCESS_TEMPLATE_URL', 'https://gist.githubusercontent.com/oskosk/0dab794274742af9caddefbc73f0ad80/raw/504f60da86969a9d55487f0c4821d06928a97218/.htaccess' );

--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -46,6 +46,7 @@ require_once __DIR__ . '/class-serverpilotprovisioner.php';
 define( 'REST_API_NAMESPACE', 'jurassic.ninja' );
 define( 'COMPANION_PLUGIN_URL', 'https://github.com/Automattic/companion/archive/master.zip' );
 define( 'JETPACK_BETA_PLUGIN_URL', 'https://github.com/Automattic/jetpack-beta/releases/latest/download/jetpack-beta.zip' );
+define( 'JETPACK_BETA_PLUGIN_DEV_URL', 'https://github.com/Automattic/jetpack-beta/archive/master.zip' );
 define( 'SUBDOMAIN_MULTISITE_HTACCESS_TEMPLATE_URL', 'https://gist.githubusercontent.com/oskosk/8cac852c793df5e4946463e2e55dfdd6/raw/a60ce4122a69c1dd36c623c9b999c36c9c8d3db8/gistfile1.txt' );
 define( 'SUBDIR_MULTISITE_HTACCESS_TEMPLATE_URL', 'https://gist.githubusercontent.com/oskosk/f5febd1bb65a2ace3d35feac949b47fd/raw/6ea8ffa013056f6793d3e8775329ec74d3304835/gistfile1.txt' );
 define( 'REGULAR_SITE_HTACCESS_TEMPLATE_URL', 'https://gist.githubusercontent.com/oskosk/0dab794274742af9caddefbc73f0ad80/raw/504f60da86969a9d55487f0c4821d06928a97218/.htaccess' );


### PR DESCRIPTION
- Update URL based on hotfix on the server. See #236
- Add option for bleeding edge JP Beta. Fixes #236

This adds the ability for a radio button on Special Ops (already added on jurassic.nina) for using the bleeding edge version of JP beta instead of stable.
