### PR TITLE
Fix jetpack site purging hook

### DIFF
--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Jurassic Ninja
  * Description: Launch ephemeral instances of WordPress + Jetpack using ServerPilot and an Ubuntu Box.
- * Version: 5.11.1
+ * Version: 5.11.2
  * Author: Automattic
  *
  * @package jurassic-ninja

--- a/lib/jetpack-stuff.php
+++ b/lib/jetpack-stuff.php
@@ -24,5 +24,7 @@ add_action(
 				$return->get_error_message()
 			);
 		}
-	}
+	},
+	10,
+	2
 );


### PR DESCRIPTION
#228 introduced a hook for disconnecting sites before purging them. It was released when [Jurassic Ninja 5.11](https://github.com/Automattic/jurassic.ninja/releases/tag/5.11) got deployed.

This handler was missing its argument count on the call to `add_action`. The symptom was that the cron job running `wp jn purge` every 10 minutes, crashed with.
``
Too few arguments to function jn\{closure}(), 1 passed in class-wp-hook.php on line 294 and exactly 2 expected in lib/jetpack-stuff.php:13
```

As a result of this, sites accumulated up to the point where the system user max count was reached today. (1000 sysusers)