### PR TITLE
Update jetpack disconnect hook command

### DIFF
--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Jurassic Ninja
  * Description: Launch ephemeral instances of WordPress + Jetpack using ServerPilot and an Ubuntu Box.
- * Version: 5.11.2
+ * Version: 5.11.3
  * Author: Automattic
  *
  * @package jurassic-ninja

--- a/lib/jetpack-stuff.php
+++ b/lib/jetpack-stuff.php
@@ -11,7 +11,7 @@ namespace jn;
 add_action(
 	'jurassic_ninja_purge_site',
 	function ( $site, $user ) {
-		$command = "cd ~/apps/{$user->name}/public && wp jetpack disconnect";
+		$command = "cd ~/apps/{$user->name}/public && wp jetpack disconnect blog";
 		debug( '%s: Running commands %s', $user->id, $command );
 
 		$return = run_command_on_behalf( $site['username'], $site['password'], $command );


### PR DESCRIPTION
Jetpack's CLI now requires either `blog` or `user` for disconnecting a site. 

#### Changes introduced by this PR

* Updates the command to `wp jetpack disconnect blog`
* Bumps plugin version to 5.11.3