### PR TITLE
Add WooCommerce Payments features

### DIFF
--- a/features/plugins.php
+++ b/features/plugins.php
@@ -27,6 +27,7 @@ add_action(
 			'jetpack'               => 'Jetpack',
 			'mailpoet'              => 'Mailpoet',
 			'vaultpress'            => 'VaultPress',
+			'woocommerce-payments'  => 'WooCommerce Payments',
 			'woocommerce'           => 'WooCommerce',
 			'wordpress-beta-tester' => 'WordPress Beta Tester Plugin',
 			'wp-downgrade'          => 'WP Downgrade',

--- a/features/woocommerce-payments.php
+++ b/features/woocommerce-payments.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * WooCommerce Payments
+ *
+ * @package jurassic-ninja
+ */
+
+namespace jn;
+
+const WCPAY_DEFAULTS = array(
+	'woocommerce-payments-branch' => false,
+	'woocommerce-payments-dev-tools' => false,
+	'woocommerce-payments-jn-options' => false,
+	'woocommerce-payments-release' => false,
+);
+
+add_action(
+	'jurassic_ninja_init',
+	function () {
+		add_action(
+			'jurassic_ninja_add_features_before_auto_login',
+			function ( &$app = null, $features, $domain ) {
+				$features = array_merge( WCPAY_DEFAULTS, $features );
+				if ( ! isset( $features['woocommerce-payments'] ) ) {
+					if ( $features['woocommerce-payments-branch'] ) {
+						debug( '%s: Adding WooCommerce Payments (on the %s branch)', $domain, $features['woocommerce-payments-branch'] );
+						add_woocommerce_payments_branch_plugin( $features['woocommerce-payments-branch'] );
+					} elseif ( $features['woocommerce-payments-release'] ) {
+						debug( '%s: Adding WooCommerce Payments (version %s)', $domain, $features['woocommerce-payments-release'] );
+						add_woocommerce_payments_release_plugin( $features['woocommerce-payments-release'] );
+					}
+				}
+
+				if ( $features['woocommerce-payments-dev-tools'] ) {
+					debug( '%s: Adding WooCommerce Payments Dev Tools', $domain );
+					add_woocommerce_payments_dev_tools();
+				}
+
+				if ( $features['woocommerce-payments-jn-options'] ) {
+					debug( '%s: Adding WooCommerce Payments Jurassic Ninja Options', $domain );
+					add_woocommerce_payments_jurassic_ninja_options();
+				}
+			},
+			10,
+			3
+		);
+
+		add_filter(
+			'jurassic_ninja_rest_feature_defaults',
+			function ( $defaults ) {
+				return array_merge( $defaults, WCPAY_DEFAULTS );
+			}
+		);
+
+		add_filter(
+			'jurassic_ninja_rest_create_request_features',
+			function ( $features, $json_params ) {
+				if ( isset( $json_params['woocommerce-payments-branch'] ) ) {
+					$features['woocommerce-payments-branch'] = $json_params['woocommerce-payments-branch'];
+				}
+
+				if ( isset( $json_params['woocommerce-payments-dev-tools'] ) ) {
+					$features['woocommerce-payments-dev-tools'] = true;
+				}
+
+				if ( isset( $json_params['woocommerce-payments-jn-options'] ) ) {
+					$features['woocommerce-payments-jn-options'] = true;
+				}
+
+				if ( isset( $json_params['woocommerce-payments-release'] ) ) {
+					$features['woocommerce-payments-release'] = $json_params['woocommerce-payments-release'];
+				}
+
+				return $features;
+			},
+			10,
+			2
+		);
+	}
+);
+
+/**
+ * Builds, installs and activates the WooCommerce Payments plugin on the site
+ * for a given branch.
+ *
+ * @param string $branch The WooCommerce Payments branch to install.
+ */
+function add_woocommerce_payments_branch_plugin( $branch ) {
+	$cmd = 'curl https://gist.githubusercontent.com/aprea/45a7f3b3583ff65a658d303c2e5a6207/raw --output build-woocommerce-payments.sh'
+		. " && source build-woocommerce-payments.sh $branch"
+		. ' && wp plugin activate woocommerce-payments';
+
+	add_filter(
+		'jurassic_ninja_feature_command',
+		function ( $s ) use ( $cmd ) {
+			return "$s && $cmd";
+		}
+	);
+}
+
+/**
+ * Installs and activates the WooCommerce Payments plugin on the site
+ * for a given release tag.
+ *
+ * @param string $release_tag The WooCommerce Payments release tag to install.
+ */
+function add_woocommerce_payments_release_plugin( $release_tag ) {
+	$woocommerce_payments_release_tag_url = "https://github.com/Automattic/woocommerce-payments/releases/download/$release_tag/woocommerce-payments.zip";
+	$cmd = "wp plugin install $woocommerce_payments_release_tag_url --activate";
+
+	add_filter(
+		'jurassic_ninja_feature_command',
+		function ( $s ) use ( $cmd ) {
+			return "$s && $cmd";
+		}
+	);
+}
+
+/**
+ * Installs and activates the WooCommerce Payments Dev Tools plugin on the site.
+ */
+function add_woocommerce_payments_dev_tools() {
+	$woocommerce_payments_dev_tools_plugin_url = 'https://github.com/Automattic/woocommerce-payments-dev-tools/archive/trunk.zip';
+	// We install the trunk version of the plugin.
+	$cmd = "wp plugin install $woocommerce_payments_dev_tools_plugin_url --activate";
+
+	add_filter(
+		'jurassic_ninja_feature_command',
+		function ( $s ) use ( $cmd ) {
+			return "$s && $cmd";
+		}
+	);
+}
+
+/**
+ * Adds a set of WordPress options to the site to make it
+ * easier to work with WooCommerce Payments on
+ * Jurassic Ninja sites.
+ */
+function add_woocommerce_payments_jurassic_ninja_options() {
+	// Disable the WPCOM request proxy and enable UPE and subscriptions features.
+	$cmd = 'wp option update wcpaydev_proxy 0'
+		. ' && wp option update _wcpay_feature_upe 1'
+		. ' && wp option update _wcpay_feature_upe_additional_payment_methods 1'
+		. ' && wp option update _wcpay_feature_subscriptions 1';
+
+	add_filter(
+		'jurassic_ninja_feature_command',
+		function ( $s ) use ( $cmd ) {
+			return "$s && $cmd";
+		}
+	);
+}

--- a/features/woocommerce-payments.php
+++ b/features/woocommerce-payments.php
@@ -8,7 +8,6 @@
 namespace jn;
 
 const WCPAY_DEFAULTS = array(
-	'woocommerce-payments-branch' => false,
 	'woocommerce-payments-dev-tools' => false,
 	'woocommerce-payments-jn-options' => false,
 	'woocommerce-payments-release' => false,
@@ -21,14 +20,9 @@ add_action(
 			'jurassic_ninja_add_features_before_auto_login',
 			function ( &$app = null, $features, $domain ) {
 				$features = array_merge( WCPAY_DEFAULTS, $features );
-				if ( ! isset( $features['woocommerce-payments'] ) ) {
-					if ( $features['woocommerce-payments-branch'] ) {
-						debug( '%s: Adding WooCommerce Payments (on the %s branch)', $domain, $features['woocommerce-payments-branch'] );
-						add_woocommerce_payments_branch_plugin( $features['woocommerce-payments-branch'] );
-					} elseif ( $features['woocommerce-payments-release'] ) {
-						debug( '%s: Adding WooCommerce Payments (version %s)', $domain, $features['woocommerce-payments-release'] );
-						add_woocommerce_payments_release_plugin( $features['woocommerce-payments-release'] );
-					}
+				if ( ! isset( $features['woocommerce-payments'] ) && $features['woocommerce-payments-release'] ) {
+					debug( '%s: Adding WooCommerce Payments (version %s)', $domain, $features['woocommerce-payments-release'] );
+					add_woocommerce_payments_release_plugin( $features['woocommerce-payments-release'] );
 				}
 
 				if ( $features['woocommerce-payments-dev-tools'] ) {
@@ -55,10 +49,6 @@ add_action(
 		add_filter(
 			'jurassic_ninja_rest_create_request_features',
 			function ( $features, $json_params ) {
-				if ( isset( $json_params['woocommerce-payments-branch'] ) ) {
-					$features['woocommerce-payments-branch'] = $json_params['woocommerce-payments-branch'];
-				}
-
 				if ( isset( $json_params['woocommerce-payments-dev-tools'] ) ) {
 					$features['woocommerce-payments-dev-tools'] = true;
 				}
@@ -78,25 +68,6 @@ add_action(
 		);
 	}
 );
-
-/**
- * Builds, installs and activates the WooCommerce Payments plugin on the site
- * for a given branch.
- *
- * @param string $branch The WooCommerce Payments branch to install.
- */
-function add_woocommerce_payments_branch_plugin( $branch ) {
-	$cmd = 'curl https://gist.githubusercontent.com/aprea/45a7f3b3583ff65a658d303c2e5a6207/raw --output build-woocommerce-payments.sh'
-		. " && source build-woocommerce-payments.sh $branch"
-		. ' && wp plugin activate woocommerce-payments';
-
-	add_filter(
-		'jurassic_ninja_feature_command',
-		function ( $s ) use ( $cmd ) {
-			return "$s && $cmd";
-		}
-	);
-}
 
 /**
  * Installs and activates the WooCommerce Payments plugin on the site

--- a/features/woocommerce-payments.php
+++ b/features/woocommerce-payments.php
@@ -59,6 +59,7 @@ add_action(
 
 				if ( isset( $json_params['woocommerce-payments-release'] ) ) {
 					$features['woocommerce-payments-release'] = $json_params['woocommerce-payments-release'];
+					$features['woocommerce'] = true;
 				}
 
 				return $features;

--- a/features/woocommerce-payments.php
+++ b/features/woocommerce-payments.php
@@ -120,7 +120,7 @@ function add_woocommerce_payments_release_plugin( $release_tag ) {
  * Installs and activates the WooCommerce Payments Dev Tools plugin on the site.
  */
 function add_woocommerce_payments_dev_tools() {
-	$woocommerce_payments_dev_tools_plugin_url = 'https://github.com/Automattic/woocommerce-payments-dev-tools/archive/trunk.zip';
+	$woocommerce_payments_dev_tools_plugin_url = 'https://github.com/Automattic/woocommerce-payments-dev-tools-ci/archive/trunk.zip';
 	// We install the trunk version of the plugin.
 	$cmd = "wp plugin install $woocommerce_payments_dev_tools_plugin_url --activate";
 

--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -126,6 +126,7 @@ function require_feature_files() {
 		'/features/gutenberg-nightly.php',
 		'/features/wordpress-4.php',
 		'/features/themes.php',
+		'/features/woocommerce-payments.php',
 	);
 
 	$available_features = apply_filters( 'jurassic_ninja_available_features', $available_features );


### PR DESCRIPTION
This PR adds 4 features to Jurassic Ninja, see below for an explanation of each feature and example usage.

### `woocommerce-payments`

This feature installs and activates the latest [WooCommerce Payments](https://wordpress.org/plugins/woocommerce-payments) plugin from WordPress.org.

Example use: `https://jurassic.ninja/create/?woocommerce-payments`

### `woocommerce-payments-branch`

~~This feature builds, installs and activates the WooCommerce Payments plugin for a given [`woocommerce-payments`](https://github.com/Automattic/woocommerce-payments) branch.~~

~~This is useful for `woocommerce-payments` code review as the pull request reviewer can quickly spin up a fresh JN site and test the proposed changes in the PR.~~

~~Example use: `https://jurassic.ninja/create/?woocommerce-payments-branch=try/jurassic-ninja`~~

**Update:** This feature was removed due to concerns about the impact on server resources and lack of a systems team maintaining it.

### `woocommerce-payments-dev-tools`

This feature installs and activates the trunk version of [`woocommerce-payments-dev-tools`](https://github.com/Automattic/woocommerce-payments-dev-tools) from GitHub.

This plugin is used alongside WooCommerce Payment for testing and development purposes.

Example use: `https://jurassic.ninja/create/?woocommerce-payments-dev-tools`

### `woocommerce-payments-jn-options`

This feature adds a set of WordPress options to the site to make it easier to work with WooCommerce Payments on Jurassic Ninja sites.

In particular, it disables the WPCOM request proxy and enables the UPE (Universal Payment Element) and subscriptions features.

Example use: `https://jurassic.ninja/create/?woocommerce-payments-jn-options`

### `woocommerce-payments-release`

This feature installs and activates the given tagged version of [`woocommerce-payments`](https://github.com/Automattic/woocommerce-payments) from GitHub.

This could be useful when we prepare testing instruction (e.g. pbPjnJ-xv-p2) for our testing partners, GlobalStep. This would allow us to provide a JN link to GlobalStep to install the specific WooCommerce Payments testing package for a given testing cycle.

It could also be useful for engineers/HEs when testing regressions. e.g. If we believe that a regression was introduced in the latest WooCommerce Payments release, we could install the prior release to confirm/deny this.

Example use: `https://jurassic.ninja/create/?woocommerce-payments-release=3.4.0`