### PR TITLE
bump smooth generator to 1.0.4

### DIFF
--- a/features/wc-smooth-generator.php
+++ b/features/wc-smooth-generator.php
@@ -7,7 +7,7 @@
 
 namespace jn;
 
-define( 'WC_SMOOTH_GENERATOR_PLUGIN_URL', 'https://github.com/woocommerce/wc-smooth-generator/releases/download/1.0.3/wc-smooth-generator.zip' );
+define( 'WC_SMOOTH_GENERATOR_PLUGIN_URL', 'https://github.com/woocommerce/wc-smooth-generator/releases/download/1.0.4/wc-smooth-generator.zip' );
 
 add_action(
 	'jurassic_ninja_init',


### PR DESCRIPTION
This PR bumps the Smooth Generator version to 1.0.4. Smooth Generator 1.0.X requires PHP 7.X.