### PR TITLE
Only load WCPay features when requested

### DIFF
--- a/features/woocommerce-payments.php
+++ b/features/woocommerce-payments.php
@@ -50,16 +50,18 @@ add_action(
 			'jurassic_ninja_rest_create_request_features',
 			function ( $features, $json_params ) {
 				if ( isset( $json_params['woocommerce-payments-dev-tools'] ) ) {
-					$features['woocommerce-payments-dev-tools'] = true;
+					$features['woocommerce-payments-dev-tools'] = $json_params['woocommerce-payments-dev-tools'];
 				}
 
 				if ( isset( $json_params['woocommerce-payments-jn-options'] ) ) {
-					$features['woocommerce-payments-jn-options'] = true;
+					$features['woocommerce-payments-jn-options'] = $json_params['woocommerce-payments-jn-options'];
 				}
 
 				if ( isset( $json_params['woocommerce-payments-release'] ) ) {
 					$features['woocommerce-payments-release'] = $json_params['woocommerce-payments-release'];
-					$features['woocommerce'] = true;
+					if ( $features['woocommerce-payments-release'] ) {
+						$features['woocommerce'] = true;
+					}
 				}
 
 				return $features;


### PR DESCRIPTION
A few WCPay features were added in #249.

Since then we received a report that these features were being added to JN sites even when not explicitly requested.

>Hi Chris it seems the Dev Tools is installed automatically even if the checkbox is unchecked, and it throws fatal when using PHP 5.6

This PR ensures that the WCPay features are only loaded when explicitly requested.

Please note that I wasn't able to test this in my local JN environment as it's not working at the moment.

I believe this approach will work as I essentially followed the convention in the [WooCommerce Smooth Generator feature](https://github.com/Automattic/jurassic.ninja/blob/master/features/wc-smooth-generator.php).