### PR TITLE
Don't activate jetpack-dev if asked jetpack-beta but also nojetpack

### DIFF
--- a/features/jetpack-beta.php
+++ b/features/jetpack-beta.php
@@ -75,6 +75,9 @@ add_action(
 
 				if ( $features['branches'] ) {
 					foreach ( $features['branches'] as $plugin_name => $branch_name ) {
+						if ( $plugin_name === 'jetpack' && isset( $features['jetpack'] ) && $features['jetpack'] === false  ) {
+							continue;
+						}
 						if ( $branch_name ) {
 							debug( '%s: Activating %s plugin %s branch in Beta plugin', $domain, $plugin_name, $branch_name );
 							activate_jetpack_branch( $plugin_name, $branch_name );

--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Jurassic Ninja
  * Description: Launch ephemeral instances of WordPress + Jetpack using ServerPilot and an Ubuntu Box.
- * Version: 5.12
+ * Version: 5.13
  * Author: Automattic
  *
  * @package jurassic-ninja


### PR DESCRIPTION
* Allows for things like https://jurassic.ninja/create/?jetpack-beta&nojetpack which currently leaves Jetpack master on
* Bumps version to 5.13