### PR TITLE
Allow all users to create

### DIFF
--- a/lib/rest-api-stuff.php
+++ b/lib/rest-api-stuff.php
@@ -17,7 +17,7 @@ if ( ! defined( '\\ABSPATH' ) ) {
 function add_rest_api_endpoints() {
 	$permission_callback = array(
 		'permission_callback' => function () {
-			return settings( 'lock_launching', false ) ? current_user_can( 'read' ) : true;
+			return settings( 'lock_launching', false ) ? is_user_logged_in() : true;
 		},
 	);
 

--- a/lib/rest-api-stuff.php
+++ b/lib/rest-api-stuff.php
@@ -17,7 +17,7 @@ if ( ! defined( '\\ABSPATH' ) ) {
 function add_rest_api_endpoints() {
 	$permission_callback = array(
 		'permission_callback' => function () {
-			return settings( 'lock_launching', false ) ? current_user_can( 'manage_options' ) : true;
+			return settings( 'lock_launching', false ) ? current_user_can( 'read' ) : true;
 		},
 	);
 


### PR DESCRIPTION
Previously, only admins could create sites. We don't want everyone with JN access to be an admin, so let's open it up a bit to any auth'd user.
