### PR TITLE
Fix specialops page for non-admins

### DIFF
--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -176,5 +176,5 @@ function page_is_launching_page() {
  * @return boolean [description]
  */
 function page_is_specialops() {
-	return current_user_can( 'manage_options' ) && 'specialops' === get_page_uri();
+	return is_user_logged_in() && 'specialops' === get_page_uri();
 }


### PR DESCRIPTION
Follow-up to #257 which changed the logic for the regular Create page. /specialops was broken for all the people moved to editor via p9dueE-4WP-p2. 

Logged in users will be able to use /specialops