### PR TITLE
Update WC Smooth Generator version

### DIFF
--- a/features/wc-smooth-generator.php
+++ b/features/wc-smooth-generator.php
@@ -7,7 +7,7 @@
 
 namespace jn;
 
-define( 'WC_SMOOTH_GENERATOR_PLUGIN_URL', 'https://github.com/woocommerce/wc-smooth-generator/releases/download/1.0.3/wc-smooth-generator.zip' );
+define( 'WC_SMOOTH_GENERATOR_PLUGIN_URL', 'https://github.com/woocommerce/wc-smooth-generator/releases/download/1.0.4/wc-smooth-generator.zip' );
 
 add_action(
 	'jurassic_ninja_init',


### PR DESCRIPTION
This pulls in the latest version of the WC Smooth Generator plugin, which includes a bug fix to ensure that it can actually run correctly.

Duplicate of and closes #250