### PR TITLE
Remove all the references to wp-log-viewer plugin

### DIFF
--- a/docs/specialops.md
+++ b/docs/specialops.md
@@ -3,6 +3,7 @@
 Similarly to the `/create` page, a `/specialops` page can be created which gives control over site configuration.
 
 Recommended `/specialops` page content:
+
 ```
 <!-- wp:paragraph {"className":"has-border","textColor":"primary","fontSize":"small"} -->
 <p class="has-border has-primary-color has-text-color has-small-font-size">IMPORTANT: Jurassic Ninja is meant to be used as an internal tool only. It’s not branded (there’s neither an intention to) and is not set up to scale to mass public use. For more questions ask in #jurassic-ninja Slack.</p>
@@ -135,9 +136,6 @@ Recommended `/specialops` page content:
 </li>
 <li style="min-width: 30%;">
 <div class="checkbox"><label><input type="checkbox" data-feature="config-constants">&nbsp;Include Config Constants plugin</label></div>
-</li>
-<li style="min-width: 30%;">
-<div class="checkbox"><label><input type="checkbox" data-feature="wp-log-viewer">&nbsp;Include WP Log Viewer plugin</label></div>
 </li>
 </ul>
 <!-- /wp:html --></div></div>

--- a/features/plugins.php
+++ b/features/plugins.php
@@ -37,7 +37,6 @@ add_action(
 			'wordpress-beta-tester' => 'WordPress Beta Tester Plugin',
 			'wp-downgrade'          => 'WP Downgrade',
 			'wp-job-manager'        => 'WP Job Manager',
-			'wp-log-viewer'         => 'WP Log Viewer',
 			'wp-rollback'           => 'WP Rollback',
 			'wp-super-cache'        => 'WP Super Cache',
 		);

--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Jurassic Ninja
  * Description: Launch ephemeral instances of WordPress + Jetpack using ServerPilot and an Ubuntu Box.
- * Version: 5.18
+ * Version: 5.18.1
  * Author: Automattic
  *
  * @package jurassic-ninja

--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -142,18 +142,21 @@ function require_feature_files() {
  * Launches a new WordPress instance on the managed server
  *
  * @param  string $php_version          The PHP version to run the app on.
- * @param  array  $requested_features   Array of features to enable.
- *        boolean config-constants      Should we add the Config Constants plugin to the site?
- *        boolean auto_ssl              Should we add Let's Encrypt-based SSL for the site?
- *        boolean ssl                   Should we add the configured SSL certificate for the site?
- *        boolean gutenberg             Should we add Gutenberg to the site?
- *        boolean jetpack               Should we add Jetpack to the site?
- *        boolean jetpack-beta          Should we add Jetpack Beta Tester plugin to the site?
- *        boolean subdir_multisite      Should we enable subdir-based multisite on the site?
- *        boolean subdir_multisite      Should we enable subdomain-based multisite on the site?
- *        boolean woocommerce           Should we add WooCommerce plugin to the site?
- *        boolean wordpress-beta-tester Should we add Jetpack Beta Tester plugin to the site?
- *        boolean wp-debug-log          Should we set WP_DEBUG and WP_DEBUG log to true ?
+ * @param  array  $requested_features {
+ *    Array of features to enable.
+ * 
+ *        @type boolean $config-constants      Should we add the Config Constants plugin to the site?
+ *        @type boolean $auto_ssl              Should we add Let's Encrypt-based SSL for the site?
+ *        @type boolean $ssl                   Should we add the configured SSL certificate for the site?
+ *        @type boolean $gutenberg             Should we add Gutenberg to the site?
+ *        @type boolean $jetpack               Should we add Jetpack to the site?
+ *        @type boolean $jetpack-beta          Should we add Jetpack Beta Tester plugin to the site?
+ *        @type boolean $subdir_multisite      Should we enable subdir-based multisite on the site?
+ *        @type boolean $subdir_multisite      Should we enable subdomain-based multisite on the site?
+ *        @type boolean $woocommerce           Should we add WooCommerce plugin to the site?
+ *        @type boolean $wordpress-beta-tester Should we add Jetpack Beta Tester plugin to the site?
+ *        @type boolean $wp-debug-log          Should we set WP_DEBUG and WP_DEBUG log to true?
+ * }
  * @param bool   $spare Spare site.
  *
  * @throws \Exception Throws on any error launching WP.

--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -154,7 +154,6 @@ function require_feature_files() {
  *        boolean woocommerce           Should we add WooCommerce plugin to the site?
  *        boolean wordpress-beta-tester Should we add Jetpack Beta Tester plugin to the site?
  *        boolean wp-debug-log          Should we set WP_DEBUG and WP_DEBUG log to true ?
- *        boolean wp-log-viewer         Should we add WP Log Viewer plugin to the site.
  * @param bool   $spare Spare site.
  *
  * @throws \Exception Throws on any error launching WP.


### PR DESCRIPTION
Fixes #266 
Fixes #355

Removes all the references of WP Log Viewer plugin that are not maintained anymore. 

I've already cleaned up the "Special Ops" page. 