### PR TITLE
Resolves #268 - add support for prepopulated data in Jetpack CRM

### DIFF
--- a/features/jetpack-crm.php
+++ b/features/jetpack-crm.php
@@ -220,7 +220,7 @@ function populate_woo_data() {
 					<li><label><input type="radio" name="jpcrm-options" data-feature="jpcrm-version" /> Version: <input type="text" id="jpcrm-version" placeholder="4.10.1"></label></li>
 					<li><label><input type="radio" name="jpcrm-options" data-feature="jpcrm-build" /> Build: <input type="text" id="jpcrm-build" placeholder="fix/314/rationalise_pi"></label></li>
 					<li><label><input type="checkbox" name="jpcrm-options" data-feature="jpcrm-populate-crm-data" /> Populate CRM data</label></li>
-					<li><label style="display:none"><input type="checkbox" name="jpcrm-options" data-feature="jpcrm-populate-woo-data" /> Populate Woo data</label></li>
+					<li style="display:none"><label><input type="checkbox" name="jpcrm-options" data-feature="jpcrm-populate-woo-data" /> Populate Woo data</label></li>
 				</ul>
 			</div>
 			<script>
@@ -230,7 +230,7 @@ function populate_woo_data() {
 						if (!e.target.checked) {
 							document.querySelector('[data-feature="jpcrm-populate-woo-data"]').checked = false;
 						}
-						document.querySelector('[data-feature="jpcrm-populate-woo-data"]').parentElement.style.display = e.target.checked ? '' : 'none';
+						document.querySelector('[data-feature="jpcrm-populate-woo-data"]').parentElement.parentElement.style.display = e.target.checked ? '' : 'none';
 					}
 				}
 

--- a/features/jetpack-crm.php
+++ b/features/jetpack-crm.php
@@ -224,6 +224,7 @@ function populate_woo_data() {
 				</ul>
 			</div>
 			<script>
+				// hide/show "populate Woo data" option depending on Woo plugin selection
 				function jpcrm_toggle_woo_populate_button(e) {
 					if (e.target.dataset['feature'] && e.target.dataset['feature'] === 'woocommerce') {
 						if (!e.target.checked) {
@@ -232,7 +233,14 @@ function populate_woo_data() {
 						document.querySelector('[data-feature="jpcrm-populate-woo-data"]').parentElement.style.display = e.target.checked ? '' : 'none';
 					}
 				}
-				document.querySelector('.entry-content').addEventListener( 'click', jpcrm_toggle_woo_populate_button );
+
+				// select radio button associated with input
+				function jpcrm_select_associated_radio_button(e) {
+					e.target.parentElement.children[0].checked = true;
+				}
+
+				document.querySelector('.entry-content').addEventListener('click', jpcrm_toggle_woo_populate_button);
+				document.querySelectorAll('#jpcrm-version, #jpcrm-build').forEach(i => i.addEventListener('click', jpcrm_select_associated_radio_button));
 
 			</script>
 		<?php

--- a/features/jetpack-crm.php
+++ b/features/jetpack-crm.php
@@ -223,6 +223,18 @@ function populate_woo_data() {
 					<li><label style="display:none"><input type="checkbox" name="jpcrm-options" data-feature="jpcrm-populate-woo-data" /> Populate Woo data</label></li>
 				</ul>
 			</div>
+			<script>
+				function jpcrm_toggle_woo_populate_button(e) {
+					if (e.target.dataset['feature'] && e.target.dataset['feature'] === 'woocommerce') {
+						if (!e.target.checked) {
+							document.querySelector('[data-feature="jpcrm-populate-woo-data"]').checked = false;
+						}
+						document.querySelector('[data-feature="jpcrm-populate-woo-data"]').parentElement.style.display = e.target.checked ? '' : 'none';
+					}
+				}
+				document.querySelector('.entry-content').addEventListener( 'click', jpcrm_toggle_woo_populate_button );
+
+			</script>
 		<?php
 		return ob_get_clean();
 	}

--- a/features/jetpack-crm.php
+++ b/features/jetpack-crm.php
@@ -58,7 +58,6 @@ add_action(
 					if ( $features['jpcrm-populate-woo-data'] ) {
 						populate_woo_data();
 					}
-
 				}
 
 			},
@@ -174,7 +173,7 @@ function add_jpcrm_sdg() {
  * Populates Jetpack CRM with data from JPCRM SDG.
  */
 function populate_crm_data() {
-	$cmd = "wp jpcrmsdg --objtype=all";
+	$cmd = 'wp jpcrmsdg --objtype=all';
 
 	add_filter(
 		'jurassic_ninja_feature_command',
@@ -188,7 +187,7 @@ function populate_crm_data() {
  * Populates Woo with data from JPCRM SDG.
  */
 function populate_woo_data() {
-	$cmd = "wp jpcrmsdg --objtype=woo";
+	$cmd = 'wp jpcrmsdg --objtype=woo';
 
 	add_filter(
 		'jurassic_ninja_feature_command',

--- a/features/jetpack-crm.php
+++ b/features/jetpack-crm.php
@@ -15,6 +15,8 @@ add_action(
 			'jpcrm' => false,
 			'jpcrm-build' => false,
 			'jpcrm-version' => false,
+			'jpcrm-populate-crm-data' => false,
+			'jpcrm-populate-woo-data' => false,
 		);
 
 		add_action(
@@ -48,6 +50,17 @@ add_action(
 
 				}
 
+				if ( $features['jpcrm-populate-crm-data'] || $features['jpcrm-populate-woo-data'] ) {
+					add_jpcrm_sdg();
+					if ( $features['jpcrm-populate-crm-data'] ) {
+						populate_crm_data();
+					}
+					if ( $features['jpcrm-populate-woo-data'] ) {
+						populate_woo_data();
+					}
+
+				}
+
 			},
 			10,
 			3
@@ -67,6 +80,14 @@ add_action(
 
 				if ( isset( $json_params['jpcrm-build'] ) ) {
 					$features['jpcrm-build'] = $json_params['jpcrm-build'];
+				}
+
+				if ( isset( $json_params['jpcrm-populate-crm-data'] ) ) {
+					$features['jpcrm-populate-crm-data'] = $json_params['jpcrm-populate-crm-data'];
+				}
+
+				if ( isset( $json_params['jpcrm-populate-woo-data'] ) ) {
+					$features['jpcrm-populate-woo-data'] = $json_params['jpcrm-populate-woo-data'];
 				}
 
 				return $features;
@@ -134,6 +155,50 @@ function add_jpcrm_from_custom_build( $build ) {
 }
 
 /**
+ * Installs and activates Jetpack CRM Sample Data Generator.
+ */
+function add_jpcrm_sdg() {
+	$jpcrm_sdg_url = 'https://jetpackcrm-builds.s3.amazonaws.com/jpcrm-sdg/jpcrm-sdg.zip';
+
+	$cmd = "wp plugin install $jpcrm_sdg_url --activate";
+
+	add_filter(
+		'jurassic_ninja_feature_command',
+		function ( $s ) use ( $cmd ) {
+			return "$s && $cmd";
+		}
+	);
+}
+
+/**
+ * Populates Jetpack CRM with data from JPCRM SDG.
+ */
+function populate_crm_data() {
+	$cmd = "wp jpcrmsdg --objtype=all";
+
+	add_filter(
+		'jurassic_ninja_feature_command',
+		function ( $s ) use ( $cmd ) {
+			return "$s && $cmd";
+		}
+	);
+}
+
+/**
+ * Populates Woo with data from JPCRM SDG.
+ */
+function populate_woo_data() {
+	$cmd = "wp jpcrmsdg --objtype=woo";
+
+	add_filter(
+		'jurassic_ninja_feature_command',
+		function ( $s ) use ( $cmd ) {
+			return "$s && $cmd";
+		}
+	);
+}
+
+/**
  * Register a shortcode which renders Jetpack Licensing controls suitable for SpecialOps usage.
  */
 \add_shortcode(
@@ -154,6 +219,8 @@ function add_jpcrm_from_custom_build( $build ) {
 					<li><label><input type="radio" name="jpcrm-options" checked /> WP.org</label></li>
 					<li><label><input type="radio" name="jpcrm-options" data-feature="jpcrm-version" /> Version: <input type="text" id="jpcrm-version" placeholder="4.10.1"></label></li>
 					<li><label><input type="radio" name="jpcrm-options" data-feature="jpcrm-build" /> Build: <input type="text" id="jpcrm-build" placeholder="fix/314/rationalise_pi"></label></li>
+					<li><label><input type="checkbox" name="jpcrm-options" data-feature="jpcrm-populate-crm-data" /> Populate CRM data</label></li>
+					<li><label style="display:none"><input type="checkbox" name="jpcrm-options" data-feature="jpcrm-populate-woo-data" /> Populate Woo data</label></li>
 				</ul>
 			</div>
 		<?php

--- a/features/jetpack-crm.php
+++ b/features/jetpack-crm.php
@@ -122,11 +122,11 @@ function add_jpcrm_from_wporg( $version ) {
 }
 
 /**
- * Installs and activates a specified build of Jetpack CRM from our custom build URL.
+ * Installs and activates a specified branch of Jetpack CRM from our custom build URL.
  *
- * @param string $build Hash of build to use.
+ * @param string $branch name of branch to use.
  */
-function add_jpcrm_from_custom_build( $build ) {
+function add_jpcrm_from_custom_build( $branch ) {
 
 	// phpcs:disable Squiz.PHP.CommentedOutCode.Found
 
@@ -138,11 +138,11 @@ function add_jpcrm_from_custom_build( $build ) {
 	 */
 	// phpcs:enable
 
-	$clean_build = str_replace( '/', '_', $build );
+	$clean_branch = str_replace( '/', '_', $branch );
 
 	// note that this public link is in a public repo
 	$jpcrm_build_base_url = 'https://jetpackcrm-builds.s3.amazonaws.com/builds/';
-	$jpcrm_build_url = $jpcrm_build_base_url . 'zero-bs-crm-' . $clean_build . '.zip';
+	$jpcrm_build_url = $jpcrm_build_base_url . 'zero-bs-crm-' . $clean_branch . '.zip';
 
 	$cmd = "wp plugin install $jpcrm_build_url --activate";
 

--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -144,7 +144,7 @@ function require_feature_files() {
  * @param  string $php_version          The PHP version to run the app on.
  * @param  array  $requested_features {
  *    Array of features to enable.
- * 
+ *
  *        @type boolean $config-constants      Should we add the Config Constants plugin to the site?
  *        @type boolean $auto_ssl              Should we add Let's Encrypt-based SSL for the site?
  *        @type boolean $ssl                   Should we add the configured SSL certificate for the site?


### PR DESCRIPTION
Resolves #268 - add support for prepopulated data in Jetpack CRM

This adds a few tweaks to the Jetpack CRM section to allow us to more quickly and easily test various scenarios.

If `jpcrm-populate-crm-data` or `jpcrm-populate-woo-data` features are selected, it installs our Jetpack CRM Sample Data Generator plugin and runs a relevant command to populate data. If WooCommerce is not selected, the Woo data populator option will not show.

Also, it adds a tweak to select the radio button associated with a given JPCRM install version.