### PR TITLE
Bump version to 5.20

### DIFF
--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Jurassic Ninja
  * Description: Launch ephemeral instances of WordPress + Jetpack using ServerPilot and an Ubuntu Box.
- * Version: 5.19
+ * Version: 5.20
  * Author: Automattic
  *
  * @package jurassic-ninja


### PR DESCRIPTION
I merged https://github.com/Automattic/jurassic.ninja/pull/271 bumping to 5.19, but then it turned out there was already a [release 5.19](https://github.com/Automattic/jurassic.ninja/releases/tag/5.19) pointing to trunk and 5.18.1.

So with 5.20 I'll synchronize by creating a new release 5.20.

(The only reason why this matters is for being able to rapidly understand what version of JN is running in prod in case there's a bug or regression live on JN)