### PR TITLE
Add WooCommerce Beta Tester Live Branches Integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 		"php": "~7.1 || 8.*"
 	},
 	"require-dev": {
-		"automattic/jetpack-codesniffer": "^2.0",
+		"automattic/jetpack-codesniffer": "2.6.0",
 		"brain/monkey": "^2.6",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
 		"phpunit/phpunit": "7.* || 8.*",

--- a/features/woocommerce-beta-tester.php
+++ b/features/woocommerce-beta-tester.php
@@ -74,7 +74,7 @@ add_action(
 					}
 				}
 
-				if (isset( $json_params['woocommerce-beta-tester-live-branch'] ) ) {
+				if ( isset( $json_params['woocommerce-beta-tester-live-branch'] ) ) {
 					$features['woocommerce-beta-tester-live-branch'] = $json_params['woocommerce-beta-tester-live-branch'];
 				}
 				
@@ -125,11 +125,11 @@ function get_woocommerce_beta_tester_zip_url() {
 				return strpos( $release['tag_name'], "wc-beta-tester" ) !== false;
 		});
 
-		usort( $releases, function ( $a, $b ) {
+		usort( $filteredReleases, function ( $a, $b ) {
 			return strtotime( $b['created_at'] ) - strtotime( $a['created_at'] );
 		});
 
-		$latestRelease = $releases[0];
+		$latestRelease = $filteredReleases[0];
 
 		$assets = $latestRelease['assets'];
 		$zip = array_filter($assets, function ($asset) {
@@ -167,7 +167,7 @@ function add_woocommerce_beta_tester_plugin() {
  * Installs and activates a live branch of WooCommerce on the site.
  */
 function add_woocommerce_live_branch( $branch_name ) {
-	$cmd = "wp wc-beta-tester install $branch_name && wp wc-beta-tester activate $branch_name";
+	$cmd = "wp wc-beta-tester deactivate_woocommerce && wp wc-beta-tester install $branch_name && wp wc-beta-tester activate $branch_name";
 	
 	add_filter(
 		'jurassic_ninja_feature_command',

--- a/features/woocommerce-beta-tester.php
+++ b/features/woocommerce-beta-tester.php
@@ -63,9 +63,7 @@ add_action(
 
 		add_filter(
 			'jurassic_ninja_rest_create_request_features',
-			function ( $features, $json_params ) {
-				// error_log("*** WOOCOMMERCE BETA TESTER ***");
-				// error_log( print_r( $json_params, true ) );
+			function ( $features, $json_params ) {				
 				if ( isset( $json_params['woocommerce-beta-tester'] ) ) {
 					$features['woocommerce-beta-tester'] = $json_params['woocommerce-beta-tester'];					
 					
@@ -145,6 +143,9 @@ function get_woocommerce_beta_tester_zip_url() {
 	}
 }
 
+/**
+ * Retrieve and install the WooCommerce Beta Tester Plugin.
+ */
 function add_woocommerce_beta_tester_plugin() {
 	$zipUrl = get_woocommerce_beta_tester_zip_url();
 	

--- a/features/woocommerce-beta-tester.php
+++ b/features/woocommerce-beta-tester.php
@@ -27,6 +27,7 @@ add_action(
 	function () {
 		$defaults = array(
 			'woocommerce-beta-tester' => false,
+			'woocommerce-beta-tester-live-branch' => false
 		);
 
 		add_action(
@@ -37,10 +38,10 @@ add_action(
 					debug( '%s: Adding WooCommerce Beta Tester Plugin', $domain );
 					add_woocommerce_beta_tester_plugin();
 				
-					if ($features['woocommerce-beta-tester-live-branch']) {
+					if ( $features['woocommerce-beta-tester-live-branch'] ) {
 						$branch = $features['woocommerce-beta-tester-live-branch'];
 
-						debug( '%s: Adding WooCommerce Beta Tester Live Branch: %s', $domain, $branch );
+						debug( '%s: Adding WooCommerce Live Branch: %s', $domain, $branch );
 						add_woocommerce_live_branch( $branch );
 					}
 				}
@@ -147,17 +148,17 @@ function get_woocommerce_beta_tester_zip_url() {
  * Retrieve and install the WooCommerce Beta Tester Plugin.
  */
 function add_woocommerce_beta_tester_plugin() {
-	$zipUrl = get_woocommerce_beta_tester_zip_url();
+	$zip_url = get_woocommerce_beta_tester_zip_url();
 	
-	if ( $zipUrl ) {
-		$cmd = "wp plugin install $zipUrl --activate";
+	if ( $zip_url ) {
+		$cmd = "wp plugin install $zip_url --activate";
 		add_filter(
 			'jurassic_ninja_feature_command',
 			function ( $s ) use ( $cmd ) {
 				return "$s && $cmd";
 			}
 		);
-	} else{
+	} else {
 		throw new Exception( 'Could not find WooCommerce Beta Tester plugin zip file.' );
 	}
 }

--- a/features/woocommerce-beta-tester.php
+++ b/features/woocommerce-beta-tester.php
@@ -64,8 +64,8 @@ add_action(
 		add_filter(
 			'jurassic_ninja_rest_create_request_features',
 			function ( $features, $json_params ) {
-				error_log("*** WOOCOMMERCE BETA TESTER ***");
-				error_log( print_r( $json_params, true ) );
+				// error_log("*** WOOCOMMERCE BETA TESTER ***");
+				// error_log( print_r( $json_params, true ) );
 				if ( isset( $json_params['woocommerce-beta-tester'] ) ) {
 					$features['woocommerce-beta-tester'] = $json_params['woocommerce-beta-tester'];					
 					

--- a/features/woocommerce-beta-tester.php
+++ b/features/woocommerce-beta-tester.php
@@ -66,12 +66,7 @@ add_action(
 			'jurassic_ninja_rest_create_request_features',
 			function ( $features, $json_params ) {				
 				if ( isset( $json_params['woocommerce-beta-tester'] ) ) {
-					$features['woocommerce-beta-tester'] = $json_params['woocommerce-beta-tester'];					
-					
-					// The WooCommerce Beta Tester Plugin works only when WooCommerce is installed and active too.
-					if ( $features['woocommerce-beta-tester'] ) {
-						$features['woocommerce'] = true;
-					}
+					$features['woocommerce-beta-tester'] = $json_params['woocommerce-beta-tester'];
 				}
 
 				if ( isset( $json_params['woocommerce-beta-tester-live-branch'] ) ) {

--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Jurassic Ninja
  * Description: Launch ephemeral instances of WordPress + Jetpack using ServerPilot and an Ubuntu Box.
- * Version: 5.20
+ * Version: 5.21
  * Author: Automattic
  *
  * @package jurassic-ninja
@@ -47,7 +47,7 @@ function init() {
 	// Create settings page.
 	add_settings_page();
 	// Settings problems include credentials and IDs not configured.
-	// if ( ! settings_problems() ) {
+	if ( ! settings_problems() ) {
 		// Include the JS only under the page which has the /create slug.
 		add_scripts();
 		// Serve the API root and nonce only under the page which has the /create slug.
@@ -57,7 +57,7 @@ function init() {
 		// Disable temporarily. Run via crontab and Jurassic Ninja's CLI
 		// add_cron_job( __FILE__ );.
 		add_admin_bar_node();
-	// }
+	}
 	/**
 	 * Done after adding settings page and before anything else related to Jurassic Ninja specifics.
 	 *
@@ -146,7 +146,7 @@ function add_scripts() {
 	add_action(
 		'wp_enqueue_scripts',
 		function () {
-			if ( true ) {
+			if ( page_is_launching_page() ) {
 				wp_enqueue_script( 'jurassicninja.js', plugins_url( '', __FILE__ ) . '/jurassicninja.js', array( 'jquery' ), '1.1', true );
 				/**
 				 * Done after enqueueing the jurassic.ninja.js file

--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -47,7 +47,7 @@ function init() {
 	// Create settings page.
 	add_settings_page();
 	// Settings problems include credentials and IDs not configured.
-	if ( ! settings_problems() ) {
+	// if ( ! settings_problems() ) {
 		// Include the JS only under the page which has the /create slug.
 		add_scripts();
 		// Serve the API root and nonce only under the page which has the /create slug.
@@ -57,7 +57,7 @@ function init() {
 		// Disable temporarily. Run via crontab and Jurassic Ninja's CLI
 		// add_cron_job( __FILE__ );.
 		add_admin_bar_node();
-	}
+	// }
 	/**
 	 * Done after adding settings page and before anything else related to Jurassic Ninja specifics.
 	 *
@@ -146,7 +146,7 @@ function add_scripts() {
 	add_action(
 		'wp_enqueue_scripts',
 		function () {
-			if ( page_is_launching_page() ) {
+			if ( true ) {
 				wp_enqueue_script( 'jurassicninja.js', plugins_url( '', __FILE__ ) . '/jurassicninja.js', array( 'jquery' ), '1.1', true );
 				/**
 				 * Done after enqueueing the jurassic.ninja.js file

--- a/jurassicninja.js
+++ b/jurassicninja.js
@@ -336,11 +336,11 @@ function getAvailableJetpackBetaPlugins() {
 	return fetch( '/wp-json/jurassic.ninja/jetpack-beta/plugins')
 		.then( response => response.json() )
 		.then( body => {
-			// let plugins = Object.keys( body.data ).map( slug => {
-			// 	return Object.assign( { slug: slug }, body.data[slug] );
-			// } );
-			// plugins.sort( ( a, b ) => a.name.localeCompare( b.name ) );
-			return [];
+			let plugins = Object.keys( body.data ).map( slug => {
+				return Object.assign( { slug: slug }, body.data[slug] );
+			} );
+			plugins.sort( ( a, b ) => a.name.localeCompare( b.name ) );
+			return plugins;
 		} );
 }
 
@@ -498,13 +498,11 @@ function hookWooCommerceBetaBranches() {
 	
 			const datalist = document.createElement('datalist');
 			datalist.id = 'woocommerce_branches';
-			
-			console.log(branches);
 
 			branches.forEach( branch => {
 				const option = document.createElement('option');
 				option.innerHTML = branch.branch;
-				option.value = branch.download_url;
+				option.value = branch.branch;
 				datalist.appendChild(option);				
 			} );
 			

--- a/jurassicninja.js
+++ b/jurassicninja.js
@@ -493,15 +493,18 @@ function hookWooCommerceBetaBranches() {
 			wooBetaSelect.setAttribute('list', 'woocommerce_branches');
 			wooBetaSelect.setAttribute('type', 'text');
 			wooBetaSelect.setAttribute('Placeholder', 'Select a branch to enable');
+			wooBetaSelect.setAttribute('data-feature', 'woocommerce-beta-tester-live-branch');
 			wooBetaSelect.style.display = "none";
 	
 			const datalist = document.createElement('datalist');
 			datalist.id = 'woocommerce_branches';
 			
+			console.log(branches);
+
 			branches.forEach( branch => {
 				const option = document.createElement('option');
 				option.innerHTML = branch.branch;
-				option.value = branch.branch;
+				option.value = branch.download_url;
 				datalist.appendChild(option);				
 			} );
 			

--- a/jurassicninja.js
+++ b/jurassicninja.js
@@ -336,11 +336,11 @@ function getAvailableJetpackBetaPlugins() {
 	return fetch( '/wp-json/jurassic.ninja/jetpack-beta/plugins')
 		.then( response => response.json() )
 		.then( body => {
-			let plugins = Object.keys( body.data ).map( slug => {
-				return Object.assign( { slug: slug }, body.data[slug] );
-			} );
-			plugins.sort( ( a, b ) => a.name.localeCompare( b.name ) );
-			return plugins;
+			// let plugins = Object.keys( body.data ).map( slug => {
+			// 	return Object.assign( { slug: slug }, body.data[slug] );
+			// } );
+			// plugins.sort( ( a, b ) => a.name.localeCompare( b.name ) );
+			return [];
 		} );
 }
 


### PR DESCRIPTION
Recently we added a feature in WooCommerce Beta Tester to install a WooCommerce plugin version from branches on the WooCommerce repository.

This is an integration with that feature allowing the creation of a Jurassic Ninja site with a specific branch of WooCommerce installed.

I have tested this on the dev instance.