### PR TITLE
Always use latest release of Smooth Generator

### DIFF
--- a/features/wc-smooth-generator.php
+++ b/features/wc-smooth-generator.php
@@ -7,7 +7,7 @@
 
 namespace jn;
 
-define( 'WC_SMOOTH_GENERATOR_PLUGIN_URL', 'https://github.com/woocommerce/wc-smooth-generator/releases/download/1.0.4/wc-smooth-generator.zip' );
+define( 'WC_SMOOTH_GENERATOR_PLUGIN_URL', 'https://github.com/woocommerce/wc-smooth-generator/releases/latest/download/wc-smooth-generator.zip' );
 
 add_action(
 	'jurassic_ninja_init',


### PR DESCRIPTION
GitHub [has a shortcut](https://docs.github.com/en/repositories/releasing-projects-on-github/linking-to-releases) for downloading the latest release of a package, regardless of the version number. Let's use it so we don't have to keep updating this when a new version is released.