### PR TITLE
Add a new jetpack-beta API endpoint

### DIFF
--- a/features/jetpack-beta.php
+++ b/features/jetpack-beta.php
@@ -47,6 +47,16 @@ add_action(
 				return $output;
 			}
 		);
+
+		add_get_endpoint(
+			'jetpack-beta/branches/(?P<repo>[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+)/(?P<branch>.+)'
+			function ( $data ) {
+				$url = 'https://betadownload.jetpack.me/query-branch.php?repo=' . rawurlencode( $data['repo'] ) . '&branch=' . rawurlencode( $data['branch'] );
+				$manifest = json_decode( wp_remote_retrieve_body( wp_remote_get( $manifest_url ) ) );
+				$output = $manifest;
+				return $output;
+			}
+		);
 	}
 );
 


### PR DESCRIPTION
The new endpoint was added to the builder website with Automattic/jetpack-builder#33.

The idea is that you'll be able to hit the endpoint like `.../jetpack-beta/branches/Automattic/jetpack/remove/unneeded-deps-in-svelte-data-sync-client` and get back information [like this](https://betadownload.jetpack.me/query-branch.php?repo=Automattic/jetpack&branch=remove/unneeded-deps-in-svelte-data-sync-client) about which plugins have builds for the branch. We'll use that in the Live Branches script to stop people from being able to select plugins that aren't built for the PR and so won't work (e.g. p1680796447609329/1680796254.854139-slack-CBG1CP4EN).