### PR TITLE
Include trunk branch in the WooCommerce Beta Tester dropdown

### DIFF
--- a/jurassicninja.js
+++ b/jurassicninja.js
@@ -324,11 +324,19 @@ function getAvailableWooCommerceBetaBranches() {
 	return fetch( '/wp-json/jurassic.ninja/woocommerce-beta-tester/branches' )
 		.then( response => response.json() )
 		.then( body => {
-			if (body.data && body.data.pr) {
-				return Object.values(body.data.pr).sort((a, b) => a.branch.localeCompare(b.branch));
+			if ( !body.data ) {
+				return [];
 			}
 
-			return [];
+			let branches = [];
+			if ( body.data.pr ) {
+				branches = Object.values(body.data.pr);
+			}
+			if ( body.data.master ) {
+				branches.push( body.data.master );
+			}
+			
+			return branches.sort((a, b) => a.branch.localeCompare(b.branch));
 		} );
 }
 


### PR DESCRIPTION
p1685350748192869/1684816055.228779-slack-C03CPM3UXDJ

This PR updates `getAvailableWooCommerceBetaBranches` function to include `master` (trunk) prop so that we can see the trunk branch in the WooCommerce Beta Tester Live Branches dropdown.

I've tested this in dev console on JN.

1. Go to JN
2. Open the dev console
3. Copy and paste the `getAvailableWooCommerceBetaBranches` function
4. Run `getAvailableWooCommerceBetaBranches().then(console.log)`
5. Should see the `trunk` item in the array.
