### PR TITLE
Use latest release asset for WCPay Dev Tools (public)

### DIFF
--- a/features/woocommerce-payments.php
+++ b/features/woocommerce-payments.php
@@ -94,7 +94,7 @@ function add_woocommerce_payments_release_plugin( $release_tag ) {
  * Installs and activates the WooCommerce Payments Dev Tools plugin on the site.
  */
 function add_woocommerce_payments_dev_tools() {
-	$woocommerce_payments_dev_tools_plugin_url = 'https://github.com/Automattic/woocommerce-payments-dev-tools-ci/archive/trunk.zip';
+	$woocommerce_payments_dev_tools_plugin_url = 'https://github.com/Automattic/woocommerce-payments-dev-tools-ci/releases/latest/download/woocommerce-payments-dev-tools-trunk.zip';
 	// We install the trunk version of the plugin.
 	$cmd = "wp plugin install $woocommerce_payments_dev_tools_plugin_url --activate";
 


### PR DESCRIPTION
## Context 

The relevant code was added here https://github.com/Automattic/jurassic.ninja/pull/249
Originally, we used the private repo (`woocommerce-payments-dev-tools`), then we moved a separate public repo (`woocommerce-payments-dev-tools-ci`) - https://github.com/Automattic/jurassic.ninja/commit/3b902c0e

## What's changed here 

- Without regular update to the public repo https://github.com/Automattic/woocommerce-payments-dev-tools-ci, we face this issue https://github.com/Automattic/woocommerce-payments/issues/5032
- I suggest using the release asset to still expose the dev-tools zip file but without revealing details why we make changes. 

Also, this approach using the latest release is similar to: 
https://github.com/Automattic/jurassic.ninja/blob/a2f3ff28e299ba645c02777084fa6e0ba4cc3709/features/wc-smooth-generator.php#L10

## Test 

- Use this zip file link and install it successful on your site as a plugin https://github.com/Automattic/woocommerce-payments-dev-tools-ci/releases/latest/download/woocommerce-payments-dev-tools-trunk.zip

## Additional info 

p1686203628324279-slack-CA17PSW87