### PR TITLE
Fix way to handle default php version

### DIFF
--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Jurassic Ninja
  * Description: Launch ephemeral instances of WordPress + Jetpack using ServerPilot and an Ubuntu Box.
- * Version: 5.25
+ * Version: 5.25.1
  * Author: Automattic
  *
  * @package jurassic-ninja

--- a/lib/class-serverpilotprovisioner.php
+++ b/lib/class-serverpilotprovisioner.php
@@ -287,7 +287,7 @@ class ServerPilotProvisioner {
 	 */
 	public function update_app( $appid, $php_version = null, $domains = null ) {
 		try {
-			$php_version = 'default' === $php_version ? 'php' . array_keys( available_php_versions() )[0] : $php_version;
+			$php_version = 'default' === $php_version ? 'php' . settings( 'default_php_version' ) : $php_version;
 			$response = $this->serverpilot_instance->app_update( $appid, $php_version, $domains );
 			$this->wait_for_serverpilot_action( $response->actionid );
 			return $response->data;


### PR DESCRIPTION
We were currently picking item `0` of the array returned by `available_php_version`, now we get it from the settings