### PR TITLE
Add option for user switching plugin and add other default users

### DIFF
--- a/features/plugins.php
+++ b/features/plugins.php
@@ -32,6 +32,7 @@ add_action(
 			'jetpack-videopress'    => 'Jetpack VideoPress',
 			'zero-bs-crm'           => 'Jetpack CRM',
 			'mailpoet'              => 'Mailpoet',
+			'user-switching'        => 'User Switching',
 			'vaultpress'            => 'VaultPress',
 			'woocommerce-payments'  => 'WooCommerce Payments',
 			'woocommerce'           => 'WooCommerce',
@@ -82,6 +83,7 @@ add_action(
 						'gutenberg' => (bool) settings( 'add_gutenberg_by_default', false ),
 						'jetpack' => (bool) settings( 'add_jetpack_by_default', true ),
 						'woocommerce' => (bool) settings( 'add_woocommerce_by_default', false ),
+						'user-switching' => (bool) settings( 'add_userswitching_by_default', false ),
 					)
 				);
 			}
@@ -148,6 +150,13 @@ add_action(
 							'id' => 'add_woocommerce_by_default',
 							'title' => __( 'Add WooCommerce to every launched WordPress', 'jurassic-ninja' ),
 							'text' => __( 'Install and activate WooCommerce on launch', 'jurassic-ninja' ),
+							'type' => 'checkbox',
+							'checked' => false,
+						),
+						'add_userswitching_by_default' => array(
+							'id' => 'add_userswitching_by_default',
+							'title' => __( 'Add User Switching to every launched WordPress', 'jurassic-ninja' ),
+							'text' => __( 'Install and activate User Switching on launch', 'jurassic-ninja' ),
 							'type' => 'checkbox',
 							'checked' => false,
 						),

--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -263,6 +263,7 @@ function launch_wordpress( $php_version = 'default', $requested_features = array
 			debug( '%s: Stopping pings to Ping-O-Mattic', $app->domain );
 			stop_pingomatic();
 
+			debug( '%s: Adding additional users', $app->domain );
 			add_other_users();
 
 			debug( '%s: Adding Companion Plugin for Auto Login', $app->domain );

--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -103,6 +103,22 @@ function stop_pingomatic() {
 }
 
 /**
+ * Adds other users.
+ */
+function add_other_users() {
+	$cmd = 'wp user create editor editor@example.com --role=editor'
+			. ' && wp user create author author@example.com --role=author'
+			. ' && wp user create contributor contributor@example.com --role=contributor'
+			. ' %% wp user create subscriber subscriber@example.com --role=subscriber';
+	add_filter(
+		'jurassic_ninja_feature_command',
+		function ( $s ) use ( $cmd ) {
+			return "$s && $cmd";
+		}
+	);
+}
+
+/**
  * Just loops through a filtered array of files inside the features directory and requires them
  */
 function require_feature_files() {
@@ -246,6 +262,8 @@ function launch_wordpress( $php_version = 'default', $requested_features = array
 			// the person that launched it reaches the site, thus the site is locked for them.
 			debug( '%s: Stopping pings to Ping-O-Mattic', $app->domain );
 			stop_pingomatic();
+
+			add_other_users();
 
 			debug( '%s: Adding Companion Plugin for Auto Login', $app->domain );
 			add_auto_login( $app->password, $app->username );


### PR DESCRIPTION
Untested, but adds the option in the backend for the user switching plugin (need to add to the UI via jurassic.ninja if this is merged and to the Live Branches script) as well as default users in the other roles.

A cousin to this PR for the Jetpack Docker environment: https://github.com/Automattic/jetpack/pull/32633