### PR TITLE
Retrieve WCPay Dev Tools plugin zip from the private repo

### DIFF
--- a/features/plugins.php
+++ b/features/plugins.php
@@ -139,6 +139,12 @@ add_action(
 							'text' => __( 'Licensing API OAuth2 token to provision Jetpack products with. Leave blank to disable.', 'jurassic-ninja' ),
 							'sanitize' => false,
 						),
+						'wcpay_dev_tools_github_token' => array(
+							'id' => 'wcpay_dev_tools_github_token',
+							'title' => __( 'GitHub Token for WooPayments Dev Tool Private Repo', 'jurassic-ninja' ),
+							'text' => __( 'Set a fined-grain GitHub token with read-only access to retrieve the latest commit from the repo directly.', 'jurassic-ninja' ),
+							'sanitize' => false,
+						),
 						'add_gutenberg_by_default' => array(
 							'id' => 'add_gutenberg_by_default',
 							'title' => __( 'Add Gutenberg to every launched WordPress', 'jurassic-ninja' ),

--- a/features/woocommerce-payments.php
+++ b/features/woocommerce-payments.php
@@ -95,7 +95,7 @@ function add_woocommerce_payments_release_plugin( $release_tag ) {
  *
  * @return string|null The zip link. Null if it can not be retrieved.
  */
-function get_private_wcpay_dev_tools_zipball_link(): ?string{
+function get_private_wcpay_dev_tools_zipball_link(): ?string {
 	$response = wp_remote_head(
 		'https://api.github.com/repos/Automattic/woocommerce-payments-dev-tools-ci/zipball/trunk',
 		array(
@@ -110,15 +110,17 @@ function get_private_wcpay_dev_tools_zipball_link(): ?string{
 
 	if ( 302 === $status
 		&& is_string( $location ) &&
-		wp_http_validate_url ( $location )
+		wp_http_validate_url( $location )
 	) {
 		return $location;
 	}
 
-	push_error( new \WP_Error(
-		'wcpay_dev_tools_private_repo',
-		__('Can not retrieve the WooCommerce Payments Dev Tools private repo. The GitHub fined-grain token may be invalid.', 'jurassic-ninja' )
-	) );
+	push_error(
+		new \WP_Error(
+			'wcpay_dev_tools_private_repo',
+			__( 'Can not retrieve the WooCommerce Payments Dev Tools private repo. The GitHub fined-grain token may be invalid.', 'jurassic-ninja' )
+		)
+	);
 	return null;
 }
 /**

--- a/lib/error-stuff.php
+++ b/lib/error-stuff.php
@@ -88,7 +88,7 @@ function errors() {
 /**
  * Push an error to the stack of errors that will be shown on the admin notices
  *
- * @param  WP_Error $err An error to be shown in the admin notice.
+ * @param \WP_Error $err An error to be shown in the admin notice.
  */
 function push_error( $err ) {
 	global $jurassic_ninja_errors;


### PR DESCRIPTION
### Changes on this PR 

- Add a new setting, which is a GitHub fine-grained token to fetch the latest zip version of WCPay Dev Tools private repo. 
- Use this token, send a HEAD request to GitHub API, grab the zip link.
- Use this zip link when installing WCPay Dev Tools with the fallback to the the public URL. 

### Notes  


Any review/feedback is welcome. However, please DO NOT merge this PR until getting the token based on the outcome of this request pMz3w-iBA-p2
