### PR TITLE
Change reference from $app to $db object for getting error message

### DIFF
--- a/jurassic.ninja.php
+++ b/jurassic.ninja.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Jurassic Ninja
  * Description: Launch ephemeral instances of WordPress + Jetpack using ServerPilot and an Ubuntu Box.
- * Version: 5.26.0
+ * Version: 5.26.1
  * Author: Automattic
  *
  * @package jurassic-ninja

--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -615,7 +615,7 @@ function create_php_app( $php_version, $features, $spare = false ) {
 	$db = provisioner()->create_database( $app->id, $dbname, $dbusername, $dbpassword );
 
 	if ( is_wp_error( $db ) ) {
-		throw new \Exception( 'Error creating database for app: ' . $app->get_error_message() );
+		throw new \Exception( 'Error creating database for app: ' . $db->get_error_message() );
 	}
 	if ( $spare ) {
 		log_new_unused_site( $app, $password, $features['shortlife'], is_user_logged_in() ? wp_get_current_user() : '' );


### PR DESCRIPTION
Fixes an error when tying to fetch the error message if db creation fails