### PR TITLE
Fix typo in add_other_users(): replace "%%" with "&&"

### DIFF
--- a/lib/stuff.php
+++ b/lib/stuff.php
@@ -109,7 +109,7 @@ function add_other_users() {
 	$cmd = 'wp user create editor editor@example.com --role=editor'
 			. ' && wp user create author author@example.com --role=author'
 			. ' && wp user create contributor contributor@example.com --role=contributor'
-			. ' %% wp user create subscriber subscriber@example.com --role=subscriber';
+			. ' && wp user create subscriber subscriber@example.com --role=subscriber';
 	add_filter(
 		'jurassic_ninja_feature_command',
 		function ( $s ) use ( $cmd ) {


### PR DESCRIPTION
Fixes a typo preventing site creation from working on `master`.

## Testing instructions

1. Set up a Jurassic Ninja site by following [the instructions in the repo readme](https://github.com/Automattic/jurassic.ninja/blob/master/README.md).
2. Try to launch a site by following the instructions in the repo readme and see it fail (check the `wp-content/debug.log`). :(
3. Apply this PR and see things work! :)